### PR TITLE
fix: add ignore to archived and forked repositories on search

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -306,7 +306,7 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					HasNextPage bool
 				}
 				Edges []RepositoryEdge
-			} `graphql:"repositories(first: 100, affiliations:OWNER, after: $repoCursor)"`
+			} `graphql:"repositories(first: 100, affiliations: OWNER, after: $repoCursor, isArchived: false, isFork: false)"`
 		} `graphql:"user(login: $login)"`
 	}
 
@@ -319,7 +319,7 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					HasNextPage bool
 				}
 				Edges []RepositoryEdge
-			} `graphql:"repositories(first: 100, after: $repoCursor)"`
+			} `graphql:"repositories(first: 100, after: $repoCursor, affiliations: OWNER, isArchived: false, isFork: false)"`
 		} `graphql:"organization(login: $login)"`
 	}
 


### PR DESCRIPTION
Many orgs have multiple repos that are forks and archived. adding `isArchived: false` and `isFork: false` to the `repositories` query reduces the overhead of getting metrics on non-maintained repositories and increases performance by reducing the amount of subsequent calls and iterations. This may be feature flagged via config in the future.