### PR TITLE
chore: create catalog-info.yaml for Backstage Auto Discovery

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,36 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: liatrio-otel-collector
+  description: The Liatrio distribution of the OpenTelemetry Collector
+
+  # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
+  annotations:
+    github.com/project-slug: liatrio/liatrio-otel-collector
+    # https://github.com/K-Phoen/backstage-plugin-grafana/blob/main/docs/embed-dashboards-on-page.md
+    grafana/dashboard-selector: backstage-test
+
+  # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
+  tags:
+    - go
+    - docker
+    - makefile
+
+  # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
+  # links:
+  #   - url: https://example.com/user
+  #     title: Examples Users
+  #     icon: user
+  #   - url: https://example.com/group
+  #     title: Example Group
+  #     icon: group
+
+spec:
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
+  type: service
+  # Review lifecycle and pick one of the three that make the most sense.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
+  lifecycle: production
+  # Please update to include the GitHub Team name tied to this project.
+  # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
+  owner: liatrio-team-members

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,23 +7,30 @@ metadata:
   # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
   annotations:
     github.com/project-slug: liatrio/liatrio-otel-collector
-    # https://github.com/K-Phoen/backstage-plugin-grafana/blob/main/docs/embed-dashboards-on-page.md
-    grafana/dashboard-selector: backstage-test
 
   # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
   tags:
     - go
     - docker
     - makefile
+    - o11y
+    - observability
+    - monitoring
+    - open source
+    - open telemetry
+    - otel
+    - metrics
+    - team effectiveness
+    - sensible defaults
 
   # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
-  # links:
-  #   - url: https://example.com/user
-  #     title: Examples Users
-  #     icon: user
-  #   - url: https://example.com/group
-  #     title: Example Group
-  #     icon: group
+  links:
+    - url: https://projecto11y.io
+      title: Project O11y Home Page
+      icon: web
+    - url: https://openo11y.dev
+      title: Open O11y Home Page
+      icon: web
 
 spec:
   # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
@@ -33,4 +40,4 @@ spec:
   lifecycle: production
   # Please update to include the GitHub Team name tied to this project.
   # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
-  owner: liatrio-team-members
+  owner: o11y-owners


### PR DESCRIPTION
❗ This is not ready to merge. Please review the changeset and update based on your repository. ❗

Please give the catalog-info.yaml a review. It could use tags, links, a description and the correct owner. Each section has links to the related documentation.

Review the [catalog-info.yaml docs](https://backstage.io/docs/features/software-catalog/descriptor-format/)
Check out an example of our implementation in [gratibot](https://github.com/liatrio/gratibot/blob/main/catalog-info.yaml)

After you've finished and merged, this repository will auto discover in the Liatrio Backstage instance.

For any questions, please reach out on our Slack channel: #project-backstage-foundations