### PR TITLE
build: fix Backstage catalog info links

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -16,12 +16,12 @@ metadata:
     - o11y
     - observability
     - monitoring
-    - open source
-    - open telemetry
+    - open-source
+    - open-telemetry
     - otel
     - metrics
-    - team effectiveness
-    - sensible defaults
+    - team-effectiveness
+    - sensible-defaults
 
   # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
   links:


### PR DESCRIPTION
I noticed the otel collector wasn't showing up in Backstage because of a minor issues with the tags:

```
iatrio-backstage-node-1  | [1] 2023-09-11T20:21:04.988Z catalog warn Policy check failed for component:default/liatrio-otel-collector; caused by Error: "tags.6" is not valid; expected a string that is sequences of [a-z0-9+#] separated by [-], at most 63 characters in total but found "open source"
```

With this change, the catalog info file validated successfully for me locally using the [entity-validator](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/utils/roadie-backstage-entity-validator)