### PR TITLE
feat: Convert CodeQL SVG badge to match existing badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,11 @@ jobs:
                   go-version: ${{ matrix.go }}
                   cache: false
 
-            - name: Make test-all
-              run: make test-all
+            - name: go test
+              run: go test -v ./.. -coverprofile=coverage.out -covermode=atomic
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
 
     go-semantic-release:
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,8 @@ jobs:
                   go-version: ${{ matrix.go }}
                   cache: false
 
-            - name: go test
-              run: go test -v ./.. -coverprofile=coverage.out -covermode=atomic
+            - name: Make test-all
+              run: make test-all
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build and Test
 
 on:
     pull_request:
-        branches: [main]
+        branches: [codecov]
     push:
-        branches: [main]
+        branches: [codecov]
 
 jobs:
     lint:
@@ -106,6 +106,27 @@ jobs:
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+
+    coverage:
+        runs-on: ubuntu-latest
+        needs: [test]
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+            - uses: actions/download-artifact@v3
+              with:
+                  name: coverage-artifacts
+            - name: Upload coverage report
+              uses: Wandalen/wretry.action@v1.3.0
+              with:
+                  action: codecov/codecov-action@v3
+                  with: |
+                      fail_ci_if_error: true
+                      verbose: true
+                  attempt_limit: 10
+                  attempt_delay: 15000
+
 
     go-semantic-release:
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,27 +107,6 @@ jobs:
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
 
-    coverage:
-        runs-on: ubuntu-latest
-        needs: [test]
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
-            - uses: actions/download-artifact@v3
-              with:
-                  name: coverage-artifacts
-            - name: Upload coverage report
-              uses: Wandalen/wretry.action@v1.3.0
-              with:
-                  action: codecov/codecov-action@v3
-                  with: |
-                      fail_ci_if_error: true
-                      verbose: true
-                  attempt_limit: 10
-                  attempt_delay: 15000
-
-
     go-semantic-release:
         if: ${{ github.ref == 'refs/heads/main' }}
         needs: [lint, build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,17 +126,14 @@ jobs:
                   echo "::set-output name=badge_color::$badge_color"
 
             - name: Add the CodeQL badge to the README.md
-              uses: wow-actions/add-badges@v1
+              uses: RubbaBoy/BYOB@v1.3.0
               with:
+                  NAME: CodeQL
+                  LABEL: CodeQL
+                  ICON: github
+                  STATUS: ${{ steps.check-badge.outputs.badge_status }}
+                  COLOR: ${{ steps.check-badge.outputs.badge_color }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  badges: |
-                      [
-                        {
-                          "badge": "https://img.shields.io/badge/CodeQL-${{ steps.check-badge.outputs.badge_status }}-${{ steps.check-badge.outputs.badge_color }}?style=for-the-badge",
-                          "alt": "CodeQL Badge",
-                          "link": "https://github.com/liatrio/liatrio-otel-collector/actions/workflows/github-code-scanning/codeql"
-                        }
-                      ]
 
     go-semantic-release:
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build and Test
 
 on:
     pull_request:
-        branches: [codecov]
+        branches: [main]
     push:
-        branches: [codecov]
+        branches: [main]
 
 jobs:
     lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,37 @@ jobs:
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
 
+            - name: Grab existing SVG badge and check if passing or failing
+              id: check_badge
+              env:
+                  badge_url: https://github.com/liatrio/liatrio-otel-collector/actions/workflows/github-code-scanning/codeql/badge.svg
+              run: |
+                  svg_content=$(curl -s ${{ env.badge_url }})
+                  if echo "$svg_content" | grep -qi "passing"; then
+                      badge_status="passing"
+                      badge_color="green"
+                  elif echo "$svg_content" | grep -qi "failing"; then
+                      badge_status="failing"
+                      badge_color="red"
+                  else
+                      badge_status="unknown"
+                  fi
+                  echo "::set-output name=badge_status::$badge_status"
+                  echo "::set-output name=badge_color::$badge_color"
+
+            - name: Add the CodeQL badge to the README.md
+              uses: wow-actions/add-badges@v1
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  badges: |
+                      [
+                        {
+                          "badge": "https://img.shields.io/badge/CodeQL-${{ steps.check-badge.outputs.badge_status }}-${{ steps.check-badge.outputs.badge_color }}?style=for-the-badge",
+                          "alt": "CodeQL Badge",
+                          "link": "https://github.com/liatrio/liatrio-otel-collector/actions/workflows/github-code-scanning/codeql"
+                        }
+                      ]
+
     go-semantic-release:
         if: ${{ github.ref == 'refs/heads/main' }}
         needs: [lint, build]

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -30,7 +30,7 @@ metagen:
 
 .PHONY: test
 test:
-	go test -v ./...
+	go test -v ./... -coverprofile=coverage.out -covermode=atomic
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -7,15 +7,14 @@
   <a href="https://goreportcard.com/report/github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver">
     <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver?style=for-the-badge">
   </a>
+  <a href="https://codecov.io/gh/liatrio/liatrio-otel-collector/branch/main" > 
+    <img alt="Codecov Status" src="https://img.shields.io/codecov/c/github/liatrio/liatrio-otel-collector?style=for-the-badge"/> 
+  </a>
   <a href="https://github.com/liatrio/liatrio-otel-collector/releases">
     <img alt="GitHub release" src="https://img.shields.io/github/v/release/liatrio/liatrio-otel-collector?include_prereleases&style=for-the-badge">
   </a>
   <a href="https://api.securityscorecards.dev/projects/github.com/liatrio/liatrio-otel-collector/badge">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/liatrio/liatrio-otel-collector?label=openssf%20scorecard&style=for-the-badge">
-  </a>
-  <br>
-  <a href="https://codecov.io/gh/liatrio/liatrio-otel-collector" > 
-    <img src="https://codecov.io/gh/liatrio/liatrio-otel-collector/graph/badge.svg?token=tRemsrLn0R"/> 
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://api.securityscorecards.dev/projects/github.com/liatrio/liatrio-otel-collector/badge">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/liatrio/liatrio-otel-collector?label=openssf%20scorecard&style=for-the-badge">
   </a>
+  <br>
   <a href="https://codecov.io/gh/liatrio/liatrio-otel-collector" > 
     <img src="https://codecov.io/gh/liatrio/liatrio-otel-collector/graph/badge.svg?token=tRemsrLn0R"/> 
   </a>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
   <a href="https://api.securityscorecards.dev/projects/github.com/liatrio/liatrio-otel-collector/badge">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/liatrio/liatrio-otel-collector?label=openssf%20scorecard&style=for-the-badge">
   </a>
+  <a href="https://github.com/liatrio/liatrio-otel-collector/actions/workflows/github-code-scanning/codeql">
+    <img src="https://github.com/liatrio/liatrio-otel-collector/actions/workflows/github-code-scanning/codeql/badge.svg" alt="CodeQL">
+  </a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   <a href="https://codecov.io/gh/liatrio/liatrio-otel-collector" > 
     <img src="https://codecov.io/gh/liatrio/liatrio-otel-collector/graph/badge.svg?token=tRemsrLn0R"/> 
   </a>
-
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
   <a href="https://api.securityscorecards.dev/projects/github.com/liatrio/liatrio-otel-collector/badge">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/liatrio/liatrio-otel-collector?label=openssf%20scorecard&style=for-the-badge">
   </a>
-  <a href="https://codeclimate.com/github/liatrio/liatrio-otel-collector/test_coverage">
-    <img src="https://api.codeclimate.com/v1/badges/c85dc9ae42b4a088165a/test_coverage" />
+  <a href="https://codecov.io/gh/liatrio/liatrio-otel-collector" > 
+    <img src="https://codecov.io/gh/liatrio/liatrio-otel-collector/graph/badge.svg?token=tRemsrLn0R"/> 
   </a>
+
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
   <a href="https://api.securityscorecards.dev/projects/github.com/liatrio/liatrio-otel-collector/badge">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/liatrio/liatrio-otel-collector?label=openssf%20scorecard&style=for-the-badge">
   </a>
+  <a href="https://codeclimate.com/github/liatrio/liatrio-otel-collector/test_coverage">
+    <img src="https://api.codeclimate.com/v1/badges/c85dc9ae42b4a088165a/test_coverage" />
+  </a>
 </p>
 
 ---


### PR DESCRIPTION
For CodeQL (at least the way that we are implementing it), the badge is given to use as an SVG file. I couldn't find an existing way to convert the given SVG to match the existing badges. 

I was, however, able to come up with a solution:
- Curl the badge since it's an html link
- Check if the badge contains 'passing' or 'failing'
- Create a new badge with the results
- Use an action that will add the new badge to the README.md
