### PR TITLE
test: added a test for `config.go`

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 	internal.ScraperConfig
-	// GitHubOrg is the name of the GitHub organization to srape
+	// GitHubOrg is the name of the GitHub organization to scrape
 	GitHubOrg string `mapstructure:"github_org"`
 	// SearchQuery is the query to use when defining a custom search for repository data
 	SearchQuery string `mapstructure:"search_query"`

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config_test.go
@@ -1,7 +1,6 @@
 package githubscraper
 
 import (
-	// "path/filepath"
 	"testing"
 	"time"
 
@@ -9,8 +8,6 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 
 	"github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver/internal/metadata"
-	// "github.com/stretchr/testify/require"
-	// "go.opentelemetry.io/collector/otelcol/otelcoltest"
 )
 
 // TestConfig ensures a config created with the factory is the same as one created manually with

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/config_test.go
@@ -1,0 +1,30 @@
+package githubscraper
+
+import (
+	// "path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/config/confighttp"
+
+	"github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver/internal/metadata"
+	// "github.com/stretchr/testify/require"
+	// "go.opentelemetry.io/collector/otelcol/otelcoltest"
+)
+
+// TestConfig ensures a config created with the factory is the same as one created manually with
+// the exported Config struct.
+func TestConfig(t *testing.T) {
+	factory := Factory{}
+	defaultConfig := factory.CreateDefaultConfig()
+
+	expectedConfig := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Timeout: 15 * time.Second,
+		},
+	}
+
+	assert.Equal(t, expectedConfig, defaultConfig)
+}


### PR DESCRIPTION
As the `config.go` file only exports/contains the Config struct, I added a test that'll create a config using the exported struct and one using the factory.CreateDefaultConfig() and compare them to ensure they match up, meaning the exported struct is "ok".