### PR TITLE
test: added tests for `factory.go`

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -16,7 +15,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 
 func TestCreateMetricsScraper(t *testing.T) {

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
@@ -1,0 +1,29 @@
+package githubscraper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+var creationSet = receivertest.NewNopCreateSettings()
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+}
+
+func TestCreateMetricsScraper(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, mReceiver)
+}


### PR DESCRIPTION
This commit, & subsequent PR, add tests for the `factory.go` file to cover the two functions it exports.