### PR TITLE
fix: grabbing default branch from api to compare to

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/generated*.go"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,0 @@
-ignore:
-  - "**/generated*.go

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/generated*.go

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
@@ -257,10 +257,15 @@ func (v *getBranchNamesProject) GetRepository() getBranchNamesProjectRepository 
 type getBranchNamesProjectRepository struct {
 	// Names of branches available in this repository that match the search pattern.
 	BranchNames []string `json:"branchNames"`
+	// Default branch of the repository.
+	RootRef string `json:"rootRef"`
 }
 
 // GetBranchNames returns getBranchNamesProjectRepository.BranchNames, and is useful for accessing the field via an interface.
 func (v *getBranchNamesProjectRepository) GetBranchNames() []string { return v.BranchNames }
+
+// GetRootRef returns getBranchNamesProjectRepository.RootRef, and is useful for accessing the field via an interface.
+func (v *getBranchNamesProjectRepository) GetRootRef() string { return v.RootRef }
 
 // getBranchNamesResponse is returned by getBranchNames on success.
 type getBranchNamesResponse struct {
@@ -443,6 +448,7 @@ query getBranchNames ($fullPath: ID!) {
 	project(fullPath: $fullPath) {
 		repository {
 			branchNames(searchPattern: "*", offset: 0, limit: 100000)
+			rootRef
 		}
 	}
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/genqlient.graphql
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/genqlient.graphql
@@ -41,6 +41,7 @@ query getBranchNames($fullPath: ID!) {
       # repo with just over 100,000 branches which is an extreme edge case which we believe is not
       # worth supporting.
       branchNames(searchPattern: "*", offset: 0, limit: 100000)
+      rootRef
     }
   }
 }


### PR DESCRIPTION
Was hardcoded as "main" and some repos don't use that as the default branch so it errors out