### PR TITLE
feat: added support for filtering projects by topic & search query

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/config.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/config.go
@@ -18,6 +18,6 @@ type Config struct {
 	// GitLabOrg is the name of the GitLab organization to scrape (gitlab scraper only)
 	GitLabOrg string `mapstructure:"gitlab_org"`
 
-	ProjectTopic  string `mapstructure:"project_topic"`
-	ProjectSearch string `mapstructure:"project_search"`
+	SearchTopic string `mapstructure:"search_topic"`
+	SearchQuery string `mapstructure:"search_query"`
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/config.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/config.go
@@ -17,4 +17,7 @@ type Config struct {
 	internal.ScraperConfig
 	// GitLabOrg is the name of the GitLab organization to scrape (gitlab scraper only)
 	GitLabOrg string `mapstructure:"gitlab_org"`
+
+	ProjectTopic  string `mapstructure:"project_topic"`
+	ProjectSearch string `mapstructure:"project_search"`
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
@@ -137,6 +137,7 @@ func (v *__getMergeRequestsInput) GetState() MergeRequestState { return v.State 
 type __getProjectsByTopicInput struct {
 	Org    string   `json:"org"`
 	Topics []string `json:"topics"`
+	After  *string  `json:"after"`
 }
 
 // GetOrg returns __getProjectsByTopicInput.Org, and is useful for accessing the field via an interface.
@@ -144,6 +145,25 @@ func (v *__getProjectsByTopicInput) GetOrg() string { return v.Org }
 
 // GetTopics returns __getProjectsByTopicInput.Topics, and is useful for accessing the field via an interface.
 func (v *__getProjectsByTopicInput) GetTopics() []string { return v.Topics }
+
+// GetAfter returns __getProjectsByTopicInput.After, and is useful for accessing the field via an interface.
+func (v *__getProjectsByTopicInput) GetAfter() *string { return v.After }
+
+// __getProjectsInput is used internally by genqlient
+type __getProjectsInput struct {
+	Org    string   `json:"org"`
+	Topics []string `json:"topics"`
+	After  *string  `json:"after"`
+}
+
+// GetOrg returns __getProjectsInput.Org, and is useful for accessing the field via an interface.
+func (v *__getProjectsInput) GetOrg() string { return v.Org }
+
+// GetTopics returns __getProjectsInput.Topics, and is useful for accessing the field via an interface.
+func (v *__getProjectsInput) GetTopics() []string { return v.Topics }
+
+// GetAfter returns __getProjectsInput.After, and is useful for accessing the field via an interface.
+func (v *__getProjectsInput) GetAfter() *string { return v.After }
 
 // getAllGroupProjectsGroup includes the requested fields of the GraphQL type Group.
 type getAllGroupProjectsGroup struct {
@@ -343,8 +363,20 @@ func (v *getMergeRequestsResponse) GetProject() getMergeRequestsProject { return
 //
 // The connection type for Project.
 type getProjectsByTopicProjectsProjectConnection struct {
+	// Total count of collection.
+	Count int `json:"count"`
+	// Information to aid in pagination.
+	PageInfo getProjectsByTopicProjectsProjectConnectionPageInfo `json:"pageInfo"`
 	// A list of nodes.
 	Nodes []getProjectsByTopicProjectsProjectConnectionNodesProject `json:"nodes"`
+}
+
+// GetCount returns getProjectsByTopicProjectsProjectConnection.Count, and is useful for accessing the field via an interface.
+func (v *getProjectsByTopicProjectsProjectConnection) GetCount() int { return v.Count }
+
+// GetPageInfo returns getProjectsByTopicProjectsProjectConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *getProjectsByTopicProjectsProjectConnection) GetPageInfo() getProjectsByTopicProjectsProjectConnectionPageInfo {
+	return v.PageInfo
 }
 
 // GetNodes returns getProjectsByTopicProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
@@ -382,6 +414,27 @@ func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetLastActivit
 	return v.LastActivityAt
 }
 
+// getProjectsByTopicProjectsProjectConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// Information about pagination in a connection.
+type getProjectsByTopicProjectsProjectConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor string `json:"endCursor"`
+}
+
+// GetHasNextPage returns getProjectsByTopicProjectsProjectConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *getProjectsByTopicProjectsProjectConnectionPageInfo) GetHasNextPage() bool {
+	return v.HasNextPage
+}
+
+// GetEndCursor returns getProjectsByTopicProjectsProjectConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *getProjectsByTopicProjectsProjectConnectionPageInfo) GetEndCursor() string {
+	return v.EndCursor
+}
+
 // getProjectsByTopicResponse is returned by getProjectsByTopic on success.
 type getProjectsByTopicResponse struct {
 	// Find projects visible to the current user.
@@ -392,6 +445,86 @@ type getProjectsByTopicResponse struct {
 func (v *getProjectsByTopicResponse) GetProjects() getProjectsByTopicProjectsProjectConnection {
 	return v.Projects
 }
+
+// getProjectsProjectsProjectConnection includes the requested fields of the GraphQL type ProjectConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for Project.
+type getProjectsProjectsProjectConnection struct {
+	// Total count of collection.
+	Count int `json:"count"`
+	// Information to aid in pagination.
+	PageInfo getProjectsProjectsProjectConnectionPageInfo `json:"pageInfo"`
+	// A list of nodes.
+	Nodes []getProjectsProjectsProjectConnectionNodesProject `json:"nodes"`
+}
+
+// GetCount returns getProjectsProjectsProjectConnection.Count, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnection) GetCount() int { return v.Count }
+
+// GetPageInfo returns getProjectsProjectsProjectConnection.PageInfo, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnection) GetPageInfo() getProjectsProjectsProjectConnectionPageInfo {
+	return v.PageInfo
+}
+
+// GetNodes returns getProjectsProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnection) GetNodes() []getProjectsProjectsProjectConnectionNodesProject {
+	return v.Nodes
+}
+
+// getProjectsProjectsProjectConnectionNodesProject includes the requested fields of the GraphQL type Project.
+type getProjectsProjectsProjectConnectionNodesProject struct {
+	// Name of the project (without namespace).
+	Name string `json:"name"`
+	// Full path of the project.
+	FullPath string `json:"fullPath"`
+	// Timestamp of the project creation.
+	CreatedAt time.Time `json:"createdAt"`
+	// Timestamp of the project last activity.
+	LastActivityAt time.Time `json:"lastActivityAt"`
+}
+
+// GetName returns getProjectsProjectsProjectConnectionNodesProject.Name, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionNodesProject) GetName() string { return v.Name }
+
+// GetFullPath returns getProjectsProjectsProjectConnectionNodesProject.FullPath, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionNodesProject) GetFullPath() string { return v.FullPath }
+
+// GetCreatedAt returns getProjectsProjectsProjectConnectionNodesProject.CreatedAt, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionNodesProject) GetCreatedAt() time.Time {
+	return v.CreatedAt
+}
+
+// GetLastActivityAt returns getProjectsProjectsProjectConnectionNodesProject.LastActivityAt, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionNodesProject) GetLastActivityAt() time.Time {
+	return v.LastActivityAt
+}
+
+// getProjectsProjectsProjectConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
+// The GraphQL type's documentation follows.
+//
+// Information about pagination in a connection.
+type getProjectsProjectsProjectConnectionPageInfo struct {
+	// When paginating forwards, are there more items?
+	HasNextPage bool `json:"hasNextPage"`
+	// When paginating forwards, the cursor to continue.
+	EndCursor string `json:"endCursor"`
+}
+
+// GetHasNextPage returns getProjectsProjectsProjectConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionPageInfo) GetHasNextPage() bool { return v.HasNextPage }
+
+// GetEndCursor returns getProjectsProjectsProjectConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
+func (v *getProjectsProjectsProjectConnectionPageInfo) GetEndCursor() string { return v.EndCursor }
+
+// getProjectsResponse is returned by getProjects on success.
+type getProjectsResponse struct {
+	// Find projects visible to the current user.
+	Projects getProjectsProjectsProjectConnection `json:"projects"`
+}
+
+// GetProjects returns getProjectsResponse.Projects, and is useful for accessing the field via an interface.
+func (v *getProjectsResponse) GetProjects() getProjectsProjectsProjectConnection { return v.Projects }
 
 // The query or mutation executed by getAllGroupProjects.
 const getAllGroupProjects_Operation = `
@@ -539,10 +672,64 @@ func getMergeRequests(
 	return &data, err
 }
 
+// The query or mutation executed by getProjects.
+const getProjects_Operation = `
+query getProjects ($org: String!, $topics: [String!], $after: String) {
+	projects(search: $org, topics: $topics, after: $after) {
+		count
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
+		nodes {
+			name
+			fullPath
+			createdAt
+			lastActivityAt
+		}
+	}
+}
+`
+
+func getProjects(
+	ctx context.Context,
+	client graphql.Client,
+	org string,
+	topics []string,
+	after *string,
+) (*getProjectsResponse, error) {
+	req := &graphql.Request{
+		OpName: "getProjects",
+		Query:  getProjects_Operation,
+		Variables: &__getProjectsInput{
+			Org:    org,
+			Topics: topics,
+			After:  after,
+		},
+	}
+	var err error
+
+	var data getProjectsResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
 // The query or mutation executed by getProjectsByTopic.
 const getProjectsByTopic_Operation = `
-query getProjectsByTopic ($org: String!, $topics: [String!]) {
-	projects(searchNamespaces: true, search: $org, topics: $topics) {
+query getProjectsByTopic ($org: String!, $topics: [String!], $after: String) {
+	projects(searchNamespaces: true, search: $org, topics: $topics, after: $after) {
+		count
+		pageInfo {
+			hasNextPage
+			endCursor
+		}
 		nodes {
 			name
 			fullPath
@@ -558,6 +745,7 @@ func getProjectsByTopic(
 	client graphql.Client,
 	org string,
 	topics []string,
+	after *string,
 ) (*getProjectsByTopicResponse, error) {
 	req := &graphql.Request{
 		OpName: "getProjectsByTopic",
@@ -565,6 +753,7 @@ func getProjectsByTopic(
 		Variables: &__getProjectsByTopicInput{
 			Org:    org,
 			Topics: topics,
+			After:  after,
 		},
 	}
 	var err error

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/generated.go
@@ -137,7 +137,6 @@ func (v *__getMergeRequestsInput) GetState() MergeRequestState { return v.State 
 type __getProjectsByTopicInput struct {
 	Org    string   `json:"org"`
 	Topics []string `json:"topics"`
-	After  *string  `json:"after"`
 }
 
 // GetOrg returns __getProjectsByTopicInput.Org, and is useful for accessing the field via an interface.
@@ -145,25 +144,6 @@ func (v *__getProjectsByTopicInput) GetOrg() string { return v.Org }
 
 // GetTopics returns __getProjectsByTopicInput.Topics, and is useful for accessing the field via an interface.
 func (v *__getProjectsByTopicInput) GetTopics() []string { return v.Topics }
-
-// GetAfter returns __getProjectsByTopicInput.After, and is useful for accessing the field via an interface.
-func (v *__getProjectsByTopicInput) GetAfter() *string { return v.After }
-
-// __getProjectsInput is used internally by genqlient
-type __getProjectsInput struct {
-	Org    string   `json:"org"`
-	Topics []string `json:"topics"`
-	After  *string  `json:"after"`
-}
-
-// GetOrg returns __getProjectsInput.Org, and is useful for accessing the field via an interface.
-func (v *__getProjectsInput) GetOrg() string { return v.Org }
-
-// GetTopics returns __getProjectsInput.Topics, and is useful for accessing the field via an interface.
-func (v *__getProjectsInput) GetTopics() []string { return v.Topics }
-
-// GetAfter returns __getProjectsInput.After, and is useful for accessing the field via an interface.
-func (v *__getProjectsInput) GetAfter() *string { return v.After }
 
 // getAllGroupProjectsGroup includes the requested fields of the GraphQL type Group.
 type getAllGroupProjectsGroup struct {
@@ -363,20 +343,8 @@ func (v *getMergeRequestsResponse) GetProject() getMergeRequestsProject { return
 //
 // The connection type for Project.
 type getProjectsByTopicProjectsProjectConnection struct {
-	// Total count of collection.
-	Count int `json:"count"`
-	// Information to aid in pagination.
-	PageInfo getProjectsByTopicProjectsProjectConnectionPageInfo `json:"pageInfo"`
 	// A list of nodes.
 	Nodes []getProjectsByTopicProjectsProjectConnectionNodesProject `json:"nodes"`
-}
-
-// GetCount returns getProjectsByTopicProjectsProjectConnection.Count, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnection) GetCount() int { return v.Count }
-
-// GetPageInfo returns getProjectsByTopicProjectsProjectConnection.PageInfo, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnection) GetPageInfo() getProjectsByTopicProjectsProjectConnectionPageInfo {
-	return v.PageInfo
 }
 
 // GetNodes returns getProjectsByTopicProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
@@ -414,27 +382,6 @@ func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetLastActivit
 	return v.LastActivityAt
 }
 
-// getProjectsByTopicProjectsProjectConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
-// The GraphQL type's documentation follows.
-//
-// Information about pagination in a connection.
-type getProjectsByTopicProjectsProjectConnectionPageInfo struct {
-	// When paginating forwards, are there more items?
-	HasNextPage bool `json:"hasNextPage"`
-	// When paginating forwards, the cursor to continue.
-	EndCursor string `json:"endCursor"`
-}
-
-// GetHasNextPage returns getProjectsByTopicProjectsProjectConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionPageInfo) GetHasNextPage() bool {
-	return v.HasNextPage
-}
-
-// GetEndCursor returns getProjectsByTopicProjectsProjectConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionPageInfo) GetEndCursor() string {
-	return v.EndCursor
-}
-
 // getProjectsByTopicResponse is returned by getProjectsByTopic on success.
 type getProjectsByTopicResponse struct {
 	// Find projects visible to the current user.
@@ -445,86 +392,6 @@ type getProjectsByTopicResponse struct {
 func (v *getProjectsByTopicResponse) GetProjects() getProjectsByTopicProjectsProjectConnection {
 	return v.Projects
 }
-
-// getProjectsProjectsProjectConnection includes the requested fields of the GraphQL type ProjectConnection.
-// The GraphQL type's documentation follows.
-//
-// The connection type for Project.
-type getProjectsProjectsProjectConnection struct {
-	// Total count of collection.
-	Count int `json:"count"`
-	// Information to aid in pagination.
-	PageInfo getProjectsProjectsProjectConnectionPageInfo `json:"pageInfo"`
-	// A list of nodes.
-	Nodes []getProjectsProjectsProjectConnectionNodesProject `json:"nodes"`
-}
-
-// GetCount returns getProjectsProjectsProjectConnection.Count, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnection) GetCount() int { return v.Count }
-
-// GetPageInfo returns getProjectsProjectsProjectConnection.PageInfo, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnection) GetPageInfo() getProjectsProjectsProjectConnectionPageInfo {
-	return v.PageInfo
-}
-
-// GetNodes returns getProjectsProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnection) GetNodes() []getProjectsProjectsProjectConnectionNodesProject {
-	return v.Nodes
-}
-
-// getProjectsProjectsProjectConnectionNodesProject includes the requested fields of the GraphQL type Project.
-type getProjectsProjectsProjectConnectionNodesProject struct {
-	// Name of the project (without namespace).
-	Name string `json:"name"`
-	// Full path of the project.
-	FullPath string `json:"fullPath"`
-	// Timestamp of the project creation.
-	CreatedAt time.Time `json:"createdAt"`
-	// Timestamp of the project last activity.
-	LastActivityAt time.Time `json:"lastActivityAt"`
-}
-
-// GetName returns getProjectsProjectsProjectConnectionNodesProject.Name, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionNodesProject) GetName() string { return v.Name }
-
-// GetFullPath returns getProjectsProjectsProjectConnectionNodesProject.FullPath, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionNodesProject) GetFullPath() string { return v.FullPath }
-
-// GetCreatedAt returns getProjectsProjectsProjectConnectionNodesProject.CreatedAt, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionNodesProject) GetCreatedAt() time.Time {
-	return v.CreatedAt
-}
-
-// GetLastActivityAt returns getProjectsProjectsProjectConnectionNodesProject.LastActivityAt, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionNodesProject) GetLastActivityAt() time.Time {
-	return v.LastActivityAt
-}
-
-// getProjectsProjectsProjectConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
-// The GraphQL type's documentation follows.
-//
-// Information about pagination in a connection.
-type getProjectsProjectsProjectConnectionPageInfo struct {
-	// When paginating forwards, are there more items?
-	HasNextPage bool `json:"hasNextPage"`
-	// When paginating forwards, the cursor to continue.
-	EndCursor string `json:"endCursor"`
-}
-
-// GetHasNextPage returns getProjectsProjectsProjectConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionPageInfo) GetHasNextPage() bool { return v.HasNextPage }
-
-// GetEndCursor returns getProjectsProjectsProjectConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
-func (v *getProjectsProjectsProjectConnectionPageInfo) GetEndCursor() string { return v.EndCursor }
-
-// getProjectsResponse is returned by getProjects on success.
-type getProjectsResponse struct {
-	// Find projects visible to the current user.
-	Projects getProjectsProjectsProjectConnection `json:"projects"`
-}
-
-// GetProjects returns getProjectsResponse.Projects, and is useful for accessing the field via an interface.
-func (v *getProjectsResponse) GetProjects() getProjectsProjectsProjectConnection { return v.Projects }
 
 // The query or mutation executed by getAllGroupProjects.
 const getAllGroupProjects_Operation = `
@@ -672,64 +539,10 @@ func getMergeRequests(
 	return &data, err
 }
 
-// The query or mutation executed by getProjects.
-const getProjects_Operation = `
-query getProjects ($org: String!, $topics: [String!], $after: String) {
-	projects(search: $org, topics: $topics, after: $after) {
-		count
-		pageInfo {
-			hasNextPage
-			endCursor
-		}
-		nodes {
-			name
-			fullPath
-			createdAt
-			lastActivityAt
-		}
-	}
-}
-`
-
-func getProjects(
-	ctx context.Context,
-	client graphql.Client,
-	org string,
-	topics []string,
-	after *string,
-) (*getProjectsResponse, error) {
-	req := &graphql.Request{
-		OpName: "getProjects",
-		Query:  getProjects_Operation,
-		Variables: &__getProjectsInput{
-			Org:    org,
-			Topics: topics,
-			After:  after,
-		},
-	}
-	var err error
-
-	var data getProjectsResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
 // The query or mutation executed by getProjectsByTopic.
 const getProjectsByTopic_Operation = `
-query getProjectsByTopic ($org: String!, $topics: [String!], $after: String) {
-	projects(searchNamespaces: true, search: $org, topics: $topics, after: $after) {
-		count
-		pageInfo {
-			hasNextPage
-			endCursor
-		}
+query getProjectsByTopic ($org: String!, $topics: [String!]) {
+	projects(searchNamespaces: true, search: $org, topics: $topics) {
 		nodes {
 			name
 			fullPath
@@ -745,7 +558,6 @@ func getProjectsByTopic(
 	client graphql.Client,
 	org string,
 	topics []string,
-	after *string,
 ) (*getProjectsByTopicResponse, error) {
 	req := &graphql.Request{
 		OpName: "getProjectsByTopic",
@@ -753,7 +565,6 @@ func getProjectsByTopic(
 		Variables: &__getProjectsByTopicInput{
 			Org:    org,
 			Topics: topics,
-			After:  after,
 		},
 	}
 	var err error

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -175,6 +175,10 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			IncludeSubGroups: gitlab.Bool(true),
 			Topic:            gitlab.String(gls.cfg.SearchTopic),
 			Search:           gitlab.String(gls.cfg.SearchQuery),
+			ListOptions: gitlab.ListOptions{
+				Page:    nextPage,
+				PerPage: 100,
+			},
 		})
 		if err != nil {
 			gls.logger.Sugar().Errorf("error: %v", err)

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -197,7 +197,7 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		for _, p := range projects {
 			projectList = append(projectList, gitlabProject{
 				Name:           p.Name,
-				Path:           p.Path,
+				Path:           p.PathWithNamespace,
 				CreatedAt:      *p.CreatedAt,
 				LastActivityAt: *p.LastActivityAt,
 			})

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -176,9 +176,10 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			Topic:            gitlab.String(gls.cfg.ProjectTopic),
 			Search:           gitlab.String(gls.cfg.ProjectSearch),
 		})
-		// projects, err := getProjects(ctx, graphClient, gls.cfg.GitLabOrg, gls.cfg.RepoTopics, projectsCursor)
 		if err != nil {
 			gls.logger.Sugar().Errorf("error: %v", err)
+
+			return gls.mb.Emit(), err
 		}
 
 		if len(projects) == 0 {

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -173,8 +173,8 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		// TODO: since we pass in a context already, do we need to create a new background context?
 		projects, res, err := restClient.Groups.ListGroupProjects(gls.cfg.GitLabOrg, &gitlab.ListGroupProjectsOptions{
 			IncludeSubGroups: gitlab.Bool(true),
-			Topic:            gitlab.String(gls.cfg.ProjectTopic),
-			Search:           gitlab.String(gls.cfg.ProjectSearch),
+			Topic:            gitlab.String(gls.cfg.SearchTopic),
+			Search:           gitlab.String(gls.cfg.SearchQuery),
 		})
 		if err != nil {
 			gls.logger.Sugar().Errorf("error: %v", err)

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -169,7 +169,7 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	var projectList []gitlabProject
 
-	for nextPage := 0; nextPage > 0; {
+	for nextPage := 1; nextPage > 0; {
 		// TODO: since we pass in a context already, do we need to create a new background context?
 		projects, res, err := restClient.Groups.ListGroupProjects(gls.cfg.GitLabOrg, &gitlab.ListGroupProjectsOptions{
 			IncludeSubGroups: gitlab.Bool(true),


### PR DESCRIPTION
This PR adds the ability to filter down the projects returned by the GitLab API for a group by providing a topic and/or search query to the request.