### PR TITLE
refactor: Improved overall readability of the scrapers

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory.go
@@ -39,12 +39,12 @@ func (f *Factory) CreateMetricsScraper(
 	params receiver.CreateSettings,
 	cfg internal.Config,
 ) (scraperhelper.Scraper, error) {
-	conf := cfg.(*Config)
-	s := newGitHubScraper(ctx, params, conf)
+	config := cfg.(*Config)
+	scraper := newGitHubScraper(ctx, params, config)
 
 	return scraperhelper.NewScraper(
 		TypeStr,
-		s.scrape,
-		scraperhelper.WithStart(s.start),
+		scraper.scrape,
+		scraperhelper.WithStart(scraper.start),
 	)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/factory_test.go
@@ -12,16 +12,16 @@ var creationSet = receivertest.NewNopCreateSettings()
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
-	cfg := factory.CreateDefaultConfig()
+	defaultConfig := factory.CreateDefaultConfig()
 
-	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NotNil(t, defaultConfig, "failed to create default config")
 }
 
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := Factory{}
-	cfg := factory.CreateDefaultConfig()
+	defaultConfig := factory.CreateDefaultConfig()
 
-	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, cfg)
+	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, defaultConfig)
 	assert.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/generated-graphql.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/generated-graphql.go
@@ -1396,7 +1396,7 @@ func getCommitData(
 
 // The query or mutation executed by getPullRequestData.
 const getPullRequestData_Operation = `
-query getPullRequestData ($name: String!, $owner: String!, $prFirst: Int!, $prCursor: String, $prStates: [PullRequestState!]) {
+query getPullRequestData ($name: String!, $owner: String!, $prFirst: Int!, $prCursor: String, $prStates: [PullRequestState!] = [OPEN,MERGED]) {
 	repository(name: $name, owner: $owner) {
 		pullRequests(first: $prFirst, after: $prCursor, states: $prStates) {
 			nodes {

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/genqlient.graphql
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/genqlient.graphql
@@ -110,7 +110,7 @@ query getPullRequestData(
   $prFirst: Int!
   # @genqlient(pointer: true)
   $prCursor: String
-  $prStates: [PullRequestState!]
+  $prStates: [PullRequestState!] = [OPEN, MERGED]
 ) {
   repository(name: $name, owner: $owner) {
     pullRequests(

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/genqlient.graphql
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/genqlient.graphql
@@ -3,12 +3,7 @@ query getRepoDataBySearch(
   # @genqlient(pointer: true)
   $repoCursor: String
 ) {
-  search(
-    query: $searchQuery
-    type: REPOSITORY
-    first: 100
-    after: $repoCursor
-  ) {
+  search(query: $searchQuery, type: REPOSITORY, first: 100, after: $repoCursor) {
     repositoryCount
     # @genqlient(typename: "SearchNode")
     nodes {
@@ -89,7 +84,7 @@ query getBranchData(
           aheadBy
           behindBy
         }
-        repository{
+        repository {
           name
           defaultBranchRef {
             name
@@ -113,11 +108,7 @@ query getPullRequestData(
   $prStates: [PullRequestState!] = [OPEN, MERGED]
 ) {
   repository(name: $name, owner: $owner) {
-    pullRequests(
-      first: $prFirst,
-      after: $prCursor,
-      states: $prStates
-    ) {
+    pullRequests(first: $prFirst, after: $prCursor, states: $prStates) {
       # @genqlient(typename: "PullRequestNode")
       nodes {
         ... on PullRequest {
@@ -125,7 +116,7 @@ query getPullRequestData(
           merged
           mergedAt
           mergeCommit {
-            deployments(last: 1, orderBy: {field: CREATED_AT, direction: ASC}) {
+            deployments(last: 1, orderBy: { field: CREATED_AT, direction: ASC }) {
               nodes {
                 createdAt
               }
@@ -137,14 +128,14 @@ query getPullRequestData(
         reviews(states: APPROVED, last: 1) {
           totalCount
           nodes {
-            ... on PullRequestReview{
+            ... on PullRequestReview {
               createdAt
             }
           }
         }
       }
       pageInfo {
-        hasNextPage,
+        hasNextPage
         endCursor
       }
     }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -20,21 +20,6 @@ import (
 
 var errClientNotInitErr = errors.New("http client not initialized")
 
-// A struct to hold the data for a pull request
-type pullRequest struct {
-	Title       string
-	CreatedDate time.Time
-	ClosedDate  time.Time
-}
-
-// A struct to hold the data for a repository
-type repo struct {
-	Name          string
-	Owner         string
-	DefaultBranch string
-	PullRequests  []pullRequest
-}
-
 // A struct representing the GitHubScraper.
 type githubScraper struct {
 	client   *http.Client

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -20,13 +20,14 @@ import (
 
 var errClientNotInitErr = errors.New("http client not initialized")
 
-// Not sure if this needs to be here after the refactor
+// A struct to hold the data for a pull request
 type pullRequest struct {
 	Title       string
 	CreatedDate time.Time
 	ClosedDate  time.Time
 }
 
+// A struct to hold the data for a repository
 type repo struct {
 	Name          string
 	Owner         string
@@ -34,6 +35,7 @@ type repo struct {
 	PullRequests  []pullRequest
 }
 
+// A struct representing the GitHubScraper.
 type githubScraper struct {
 	client   *http.Client
 	cfg      *Config
@@ -121,6 +123,7 @@ func processPullRequests(
 	ghs.mb.RecordGitRepositoryPullRequestMergedCountDataPoint(now, int64(mergedCount), repoName)
 }
 
+// Retrieves the commit data for a given branch.
 func (ghs *githubScraper) getCommitInfo(
 	ctx context.Context,
 	client graphql.Client,

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -62,16 +62,18 @@ func newGitHubScraper(
 	}
 }
 
+// Retrieves the pull request data for a given repository.
 func (ghs *githubScraper) getPullRequests(
 	ctx context.Context,
 	client graphql.Client,
 	repoName string,
+	prStates []PullRequestState,
 ) ([]PullRequestNode, error) {
 	var prCursor *string
 	var pullRequests []PullRequestNode
 
 	for hasNextPage := true; hasNextPage; {
-		prs, err := getPullRequestData(ctx, client, repoName, ghs.cfg.GitHubOrg, 100, prCursor, []PullRequestState{"OPEN", "MERGED"})
+		prData, err := getPullRequestData(ctx, client, repoName, ghs.cfg.GitHubOrg, 100, prCursor, prStates)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -227,17 +227,13 @@ func (ghs *githubScraper) getContributorCount(
 ) (int, error) {
 	var err error
 
-	contribs, _, err := client.Repositories.ListContributors(ctx, ghs.cfg.GitHubOrg, repo.Name, nil)
+	contributors, _, err := client.Repositories.ListContributors(ctx, ghs.cfg.GitHubOrg, repo.Name, nil)
 	if err != nil {
 		ghs.logger.Sugar().Errorf("error getting contributor count", zap.Error(err))
 		return 0, err
 	}
 
-	contribCount := 0
-	if len(contribs) > 0 {
-		contribCount = len(contribs)
-	}
-	return contribCount, nil
+	return len(contributors), nil
 }
 
 // scrape and return metrics

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -21,17 +21,17 @@ import (
 var errClientNotInitErr = errors.New("http client not initialized")
 
 // Not sure if this needs to be here after the refactor
-type PullRequest struct {
+type pullRequest struct {
 	Title       string
 	CreatedDate time.Time
 	ClosedDate  time.Time
 }
 
-type Repo struct {
+type repo struct {
 	Name          string
 	Owner         string
 	DefaultBranch string
-	PullRequests  []PullRequest
+	PullRequests  []pullRequest
 }
 
 type githubScraper struct {

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -224,7 +224,6 @@ func (ghs *githubScraper) getContributorCount(
 	ctx context.Context,
 	client *github.Client,
 	repo SearchNodeRepository,
-	now pcommon.Timestamp,
 ) (int, error) {
 	var err error
 
@@ -402,7 +401,7 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			i := i
 			sem <- 1
 			go func() {
-				contribCount, err := ghs.getContributorCount(ctx, restClient, searchRepos[i], now)
+				contribCount, err := ghs.getContributorCount(ctx, restClient, searchRepos[i])
 				if err != nil {
 					ghs.logger.Sugar().Errorf("error getting contributor count", zap.Error(err))
 					<-sem

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper_test.go
@@ -104,9 +104,8 @@ func TestGetContributorCount(t *testing.T) {
 			ghs := newGitHubScraper(context.Background(), settings, defaultConfig.(*Config))
 			ghs.cfg.GitHubOrg = tc.org
 			ctx := context.Background()
-			now := pcommon.NewTimestampFromTime(time.Now())
 
-			contribs, err := ghs.getContributorCount(ctx, client, tc.repo, now)
+			contribs, err := ghs.getContributorCount(ctx, client, tc.repo)
 			if tc.expectedErr != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectedErr.Error(), err.Error())

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper_test.go
@@ -122,10 +122,11 @@ func TestNewGitHubScraper(t *testing.T) {
 	factory := Factory{}
 	defaultConfig := factory.CreateDefaultConfig()
 
-	s := newGitHubScraper(context.Background(), receiver.CreateSettings{}, defaultConfig.(*Config))
+	scraper := newGitHubScraper(context.Background(), receiver.CreateSettings{}, defaultConfig.(*Config))
 
-	assert.NotNil(t, s)
+	assert.NotNil(t, scraper)
 }
+
 func TestGetPullRequests(t *testing.T) {
 	testCases := []struct {
 		desc            string
@@ -242,9 +243,9 @@ func TestGetPullRequests(t *testing.T) {
 			defaultConfig := factory.CreateDefaultConfig()
 			settings := receivertest.NewNopCreateSettings()
 			ghs := newGitHubScraper(context.Background(), settings, defaultConfig.(*Config))
-			prs, err := ghs.getPullRequests(context.Background(), tc.client, "repo name")
+			pullRequests, err := ghs.getPullRequests(context.Background(), tc.client, "repo name", []PullRequestState{"OPEN", "MERGED"})
 
-			assert.Equal(t, tc.expectedPrCount, len(prs))
+			assert.Equal(t, tc.expectedPrCount, len(pullRequests))
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {
@@ -253,6 +254,7 @@ func TestGetPullRequests(t *testing.T) {
 		})
 	}
 }
+
 func TestGetBranches(t *testing.T) {
 	testCases := []struct {
 		desc                string
@@ -389,7 +391,7 @@ func TestGetCommitInfo(t *testing.T) {
 		expectedErr error
 		pages       int
 		branch      BranchNode
-		//commits      CommitNodeTargetCommit
+		// commits      CommitNodeTargetCommit
 		expectedAge       int64
 		expectedAdditions int
 		expectedDeletions int
@@ -494,11 +496,11 @@ func TestGetCommitInfo(t *testing.T) {
 			settings := receivertest.NewNopCreateSettings()
 			ghs := newGitHubScraper(context.Background(), settings, defaultConfig.(*Config))
 			now := pcommon.NewTimestampFromTime(time.Now())
-			adds, dels, age, err := ghs.getCommitInfo(context.Background(), tc.client, "repo1", now, tc.pages, tc.branch)
+			commitInfo, err := ghs.getCommitInfo(context.Background(), tc.client, "repo1", now, tc.pages, tc.branch)
 
-			assert.Equal(t, tc.expectedAge, age)
-			assert.Equal(t, tc.expectedDeletions, dels)
-			assert.Equal(t, tc.expectedAdditions, adds)
+			assert.Equal(t, tc.expectedAge, commitInfo.age)
+			assert.Equal(t, tc.expectedDeletions, commitInfo.deletions)
+			assert.Equal(t, tc.expectedAdditions, commitInfo.additions)
 
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers.go
@@ -43,19 +43,23 @@ func (ghs *githubScraper) getCommitData(
 	if err != nil {
 		return nil, err
 	}
+
 	if len(data.Repository.Refs.Nodes) == 0 {
 		return nil, errors.New("no commits returned")
 	}
-	tar := data.Repository.Refs.Nodes[0].GetTarget()
-	if ct, ok := tar.(*CommitNodeTargetCommit); ok {
+
+	target := data.Repository.Refs.Nodes[0].GetTarget()
+	if ct, ok := target.(*CommitNodeTargetCommit); ok {
 		return &ct.History, nil
 	} else {
 		return nil, errors.New("target is not a commit")
 	}
 }
 
-func getNumPages(p float64, n float64) int {
-	numPages := math.Ceil(n / p)
+// Compute the number of pages needed to get perPage number of items
+// from total number of items
+func getNumPages(perPage float64, total float64) int {
+	numPages := math.Ceil(total / perPage)
 
 	return int(numPages)
 }
@@ -73,13 +77,13 @@ func checkOwnerTypeValid(ownertype string) (bool, error) {
 	if ownertype == "org" || ownertype == "user" {
 		return true, nil
 	}
+
 	return false, errors.New("ownertype must be either org or user")
 }
 
 // Check to ensure that the login user (org name or user id) exists or
 // can be logged into.
 func (ghs *githubScraper) checkOwnerExists(ctx context.Context, client graphql.Client, owner string) (exists bool, ownerType string, err error) {
-
 	loginResp, err := checkLogin(ctx, client, ghs.cfg.GitHubOrg)
 
 	exists = false
@@ -104,6 +108,6 @@ func (ghs *githubScraper) checkOwnerExists(ctx context.Context, client graphql.C
 
 // Returns the default search query string based on input of owner type
 // and GitHubOrg name with a default of archived:false to ignore archived repos
-func genDefaultSearchQuery(ownertype string, ghorg string) string {
-	return fmt.Sprintf("%s:%s archived:false", ownertype, ghorg)
+func genDefaultSearchQuery(ownertype string, githubOrg string) string {
+	return fmt.Sprintf("%s:%s archived:false", ownertype, githubOrg)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers_test.go
@@ -21,31 +21,31 @@ type mockClient struct {
 func (m *mockClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
 	switch op := req.OpName; op {
 	case "getPullRequestData":
-		//for forcing arbitrary errors
+		// for forcing arbitrary errors
 		if m.err {
 			return errors.New(m.errString)
 		}
-		r := resp.Data.(*getPullRequestDataResponse)
-		r.Repository.PullRequests = m.prs[m.curPage]
+		response := resp.Data.(*getPullRequestDataResponse)
+		response.Repository.PullRequests = m.prs[m.curPage]
 		m.curPage++
 
 	case "getBranchData":
 		if m.err {
 			return errors.New(m.errString)
 		}
-		r := resp.Data.(*getBranchDataResponse)
-		r.Repository.Refs = m.branchData[m.curPage]
+		response := resp.Data.(*getBranchDataResponse)
+		response.Repository.Refs = m.branchData[m.curPage]
 		m.curPage++
 
 	case "getCommitData":
 		if m.err {
 			return errors.New(m.errString)
 		}
-		r := resp.Data.(*getCommitDataResponse)
+		response := resp.Data.(*getCommitDataResponse)
 		commitNodes := []CommitNode{
 			{Target: &m.commitData},
 		}
-		r.Repository.Refs.Nodes = commitNodes
+		response.Repository.Refs.Nodes = commitNodes
 
 		// case "getRepoDataBySearch":
 	}
@@ -53,34 +53,34 @@ func (m *mockClient) MakeRequest(ctx context.Context, req *graphql.Request, resp
 }
 
 func TestGetNumPages100(t *testing.T) {
-	p := float64(100)
-	n := float64(375)
+	perPage := float64(100)
+	total := float64(375)
 
 	expected := 4
 
-	num := getNumPages(p, n)
+	num := getNumPages(perPage, total)
 
 	assert.Equal(t, expected, num)
 }
 
 func TestGetNumPages10(t *testing.T) {
-	p := float64(10)
-	n := float64(375)
+	perPage := float64(10)
+	total := float64(375)
 
 	expected := 38
 
-	num := getNumPages(p, n)
+	num := getNumPages(perPage, total)
 
 	assert.Equal(t, expected, num)
 }
 
 func TestGetNumPages1(t *testing.T) {
-	p := float64(10)
-	n := float64(1)
+	perPage := float64(10)
+	total := float64(1)
 
 	expected := 1
 
-	num := getNumPages(p, n)
+	num := getNumPages(perPage, total)
 
 	assert.Equal(t, expected, num)
 }
@@ -185,23 +185,23 @@ func TestSubNegativeFloat(t *testing.T) {
 }
 
 func TestGenDefaultSearchQueryOrg(t *testing.T) {
-	st := "org"
+	ownerType := "org"
 	org := "empire"
 
 	expected := "org:empire archived:false"
 
-	actual := genDefaultSearchQuery(st, org)
+	actual := genDefaultSearchQuery(ownerType, org)
 
 	assert.Equal(t, expected, actual)
 }
 
 func TestGenDefaultSearchQueryUser(t *testing.T) {
-	st := "user"
+	ownerType := "user"
 	org := "vader"
 
 	expected := "user:vader archived:false"
 
-	actual := genDefaultSearchQuery(st, org)
+	actual := genDefaultSearchQuery(ownerType, org)
 
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/factory.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/factory.go
@@ -39,12 +39,12 @@ func (f *Factory) CreateMetricsScraper(
 	params receiver.CreateSettings,
 	cfg internal.Config,
 ) (scraperhelper.Scraper, error) {
-	conf := cfg.(*Config)
-	s := newGitLabScraper(ctx, params, conf)
+	config := cfg.(*Config)
+	scraper := newGitLabScraper(ctx, params, config)
 
 	return scraperhelper.NewScraper(
 		TypeStr,
-		s.scrape,
-		scraperhelper.WithStart(s.start),
+		scraper.scrape,
+		scraperhelper.WithStart(scraper.start),
 	)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/factory_test.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/factory_test.go
@@ -12,16 +12,16 @@ var creationSet = receivertest.NewNopCreateSettings()
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
-	cfg := factory.CreateDefaultConfig()
+	defaultConfig := factory.CreateDefaultConfig()
 
-	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NotNil(t, defaultConfig, "failed to create default config")
 }
 
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := Factory{}
-	cfg := factory.CreateDefaultConfig()
+	defaultConfig := factory.CreateDefaultConfig()
 
-	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, cfg)
+	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, defaultConfig)
 	assert.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/genqlient.graphql
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/genqlient.graphql
@@ -1,5 +1,5 @@
 query getAllGroupProjects(
-  $fullPath: ID!,
+  $fullPath: ID!
   # @genqlient(pointer: true)
   $after: String
 ) {
@@ -66,7 +66,7 @@ query getMergeRequests(
         targetBranch
         createdAt
         mergedAt
-        diffStatsSummary{
+        diffStatsSummary {
           additions
           deletions
         }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/graphql_helpers.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/graphql_helpers.go
@@ -8,21 +8,33 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
-func (gls *gitlabScraper) getBranchNames(ctx context.Context, client graphql.Client, projectPath string) (*getBranchNamesProjectRepository, error) {
+func (gls *gitlabScraper) getBranchNames(
+	ctx context.Context,
+	client graphql.Client,
+	projectPath string,
+) (*getBranchNamesProjectRepository, error) {
 	branches, err := getBranchNames(ctx, client, projectPath)
 	if err != nil {
 		return nil, err
 	}
+
 	return &branches.Project.Repository, nil
 }
 
-func (gls *gitlabScraper) getInitialCommit(client *gitlab.Client, projectPath string, defaultBranch string, branch string) (*gitlab.Commit, error) {
+func (gls *gitlabScraper) getInitialCommit(
+	client *gitlab.Client,
+	projectPath string,
+	defaultBranch string,
+	branch string,
+) (*gitlab.Commit, error) {
 	diff, _, err := client.Repositories.Compare(projectPath, &gitlab.CompareOptions{From: &defaultBranch, To: &branch})
 	if err != nil {
 		return nil, err
 	}
+
 	if len(diff.Commits) == 0 {
 		return nil, nil
 	}
+
 	return diff.Commits[0], nil
 }


### PR DESCRIPTION
This PR is my attempt at cleaning up the GitHub & GitLab scraper code. I did the following across both of them:

- Renamed "unclear" variables to more accurate names.
  - `mrs` -> `mergeRequests`
  - `p` -> `project`
  - etc.
- Added comments where I could.
  - All the functions should have a comment to help explain a bit more of what they do.
- Reformatted various functions.
  - Some function declarations were over 100 characters long on a single line so I formatted them a bit better.