### PR TITLE
fix(config): correct environment variable syntax in config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,7 +42,7 @@ receivers:
         scrapers:
             github:
                 github_org: ${env:GITHUB_ORG}
-                search_query: org:${env.GITHUB_ORG}
+                search_query: org:${env:GITHUB_ORG}
                 ## You can specify a custom endpoint URL full list of client settings: https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp#client-configuration
                 #endpoint: "https://mygithubenterprise.com"
 


### PR DESCRIPTION
The environment variable syntax in the `config.yaml` file was incorrect. It used a '.' instead of a ':'. This commit fixes that issue by changing `${env.GITHUB_ORG}` to `${env:GITHUB_ORG}`.