### PR TITLE
feat(githubscraper): Add rate limiter

### DIFF
--- a/pkg/receiver/gitproviderreceiver/internal/common/ratelimiter.go
+++ b/pkg/receiver/gitproviderreceiver/internal/common/ratelimiter.go
@@ -1,31 +1,8 @@
 package common
 
-import (
-	"sync"
-	"time"
-)
+import "net/http"
 
-type RateLimiter struct {
-	mutex     sync.Mutex
-	remaining int       // number of remaining points
-	resetTime time.Time // time when the rate limit resets
-}
-
-func NewRateLimiter(remaining int) *RateLimiter {
-	// Set remaining to 5000 if it is not set that is the default point limit
-	// https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#primary-rate-limit
-	if remaining == 0 {
-		remaining = 5000
-	}
-	return &RateLimiter{
-		remaining: remaining,
-		resetTime: time.Now(),
-	}
-}
-
-// Decrement points in thread safe manner
-func (rl *RateLimiter) DecrementPoints(points int) {
-	rl.mutex.Lock()
-	defer rl.mutex.Unlock()
-	rl.remaining -= points
+type RateLimiter interface {
+	WaitForAvailable()
+	UpdateFromHeaders(http.Header)
 }

--- a/pkg/receiver/gitproviderreceiver/internal/common/ratelimiter.go
+++ b/pkg/receiver/gitproviderreceiver/internal/common/ratelimiter.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"sync"
+	"time"
+)
+
+type RateLimiter struct {
+	mutex     sync.Mutex
+	remaining int       // number of remaining points
+	resetTime time.Time // time when the rate limit resets
+}
+
+func NewRateLimiter(remaining int) *RateLimiter {
+	// Set remaining to 5000 if it is not set that is the default point limit
+	// https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api#primary-rate-limit
+	if remaining == 0 {
+		remaining = 5000
+	}
+	return &RateLimiter{
+		remaining: remaining,
+		resetTime: time.Now(),
+	}
+}
+
+// Decrement points in thread safe manner
+func (rl *RateLimiter) DecrementPoints(points int) {
+	rl.mutex.Lock()
+	defer rl.mutex.Unlock()
+	rl.remaining -= points
+}

--- a/pkg/receiver/gitproviderreceiver/internal/common/wrapper_client.go
+++ b/pkg/receiver/gitproviderreceiver/internal/common/wrapper_client.go
@@ -1,0 +1,25 @@
+package common
+
+import "net/http"
+
+type WrapperClient struct {
+	*http.Client
+}
+
+func NewWrapperClient(client *http.Client) *WrapperClient {
+	return &WrapperClient{client}
+}
+
+func (c *WrapperClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, values := range resp.Header {
+		if name == "X-RateLimit-Remaining" {
+			resp.Header.Set(name, values[0])
+		}
+	}
+	return resp, nil
+}

--- a/pkg/receiver/gitproviderreceiver/internal/common/wrapper_client.go
+++ b/pkg/receiver/gitproviderreceiver/internal/common/wrapper_client.go
@@ -1,13 +1,18 @@
 package common
 
-import "net/http"
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+)
 
 type WrapperClient struct {
 	*http.Client
+	logger *zap.Logger
 }
 
-func NewWrapperClient(client *http.Client) *WrapperClient {
-	return &WrapperClient{client}
+func NewWrapperClient(client *http.Client, logger *zap.Logger) *WrapperClient {
+	return &WrapperClient{client, logger}
 }
 
 func (c *WrapperClient) Do(req *http.Request) (*http.Response, error) {
@@ -17,8 +22,8 @@ func (c *WrapperClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	for name, values := range resp.Header {
-		if name == "X-RateLimit-Remaining" {
-			resp.Header.Set(name, values[0])
+		if name == "X-Ratelimit-Remaining" {
+			c.logger.Sugar().Infof("Rate limit remaining: %s", values)
 		}
 	}
 	return resp, nil

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_ratelimiter.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_ratelimiter.go
@@ -1,0 +1,92 @@
+package githubscraper
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type GitHubRateLimiter struct {
+	mutex     sync.Mutex
+	Remaining uint
+	ResetTime time.Time
+	logger    *zap.Logger
+}
+
+func NewGitHubRateLimiter(limit uint, logger *zap.Logger) *GitHubRateLimiter {
+	return &GitHubRateLimiter{
+		Remaining: limit,
+		ResetTime: time.Now(),
+		logger:    logger,
+	}
+}
+
+// Limit needs to be updated from the headers before calling this function
+// TODO: Currently this function will block all other requests due to deferring
+// the unlock on the GitHubRateLimiter struct. This might actually be good
+// since if we have determined we are rate limited we either sleep the other go
+// routines or we wait for the mutex to get unlocked.
+func (r *GitHubRateLimiter) WaitForAvailable() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	// Consider adding some padding maybe `if r.Remaining > 6`
+	// The idea being that because we loop over repos and we will spawn
+	// up to 3 goroutines per loop. We can have a situation where we have 3
+	// in flight requests from the 'end' of one loop and 3 in flight requests
+	// from the next loop.
+	if r.Remaining > 0 {
+		return
+	}
+
+	now := time.Now()
+	if now.Before(r.ResetTime) {
+		r.logger.Sugar().Infof("Rate limit reached, sleeping until %s", r.ResetTime)
+		time.Sleep(r.ResetTime.Sub(now))
+	}
+}
+
+func (r *GitHubRateLimiter) UpdateFromHeaders(headers http.Header) {
+	remaining, err := getRateLimitRemaining(headers)
+	if err != nil {
+		r.logger.Sugar().
+			Errorf("error getting rate limit remaining", zap.Error(err))
+		return
+	}
+	resetTime, err := getRateLimitResetTime(headers)
+	if err != nil {
+		r.logger.Sugar().
+			Errorf("error getting rate limit reset time", zap.Error(err))
+		return
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	// Because we issue requests in parallel we can get back responses out of
+	// order. This means that we can get a response with a lower remaining
+	// value than we currently have.
+	r.Remaining = uint(remaining)
+	r.ResetTime = resetTime
+}
+
+func getRateLimitRemaining(headers http.Header) (int, error) {
+	remaining, err := strconv.Atoi(headers.Get("X-Ratelimit-Remaining"))
+	if err != nil {
+		return 0, err
+	}
+	return remaining, nil
+}
+
+func getRateLimitResetTime(headers http.Header) (time.Time, error) {
+	resetTimeUnix, err := strconv.ParseInt(
+		headers.Get("X-Ratelimit-Reset"), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	resetTime := time.Unix(resetTimeUnix, 0)
+	return resetTime, nil
+}

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -48,7 +48,7 @@ func (ghs *githubScraper) start(_ context.Context, host component.Host) (err err
 	// TODO: Fix the ToClient configuration
 	// ghs.client, err = ghs.cfg.ToClient(host, ghs.settings)
 	client, err := ghs.cfg.ToClient(host, ghs.settings)
-	ghs.client = common.NewWrapperClient(client)
+	ghs.client = common.NewWrapperClient(client, ghs.logger)
 	// ghs.client = &common.CustomClient{UnderlyingClient: internalCLient}
 	return
 }

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -5,7 +5,6 @@ package githubscraper
 import (
 	"context"
 	"errors"
-	"net/http"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -15,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
+	"github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver/internal/common"
 	"github.com/liatrio/liatrio-otel-collector/pkg/receiver/gitproviderreceiver/internal/metadata"
 )
 
@@ -35,7 +35,7 @@ type Repo struct {
 }
 
 type githubScraper struct {
-	client   *http.Client
+	client   *common.WrapperClient
 	cfg      *Config
 	settings component.TelemetrySettings
 	logger   *zap.Logger
@@ -46,7 +46,10 @@ type githubScraper struct {
 func (ghs *githubScraper) start(_ context.Context, host component.Host) (err error) {
 	ghs.logger.Sugar().Info("Starting the scraper inside scraper.go")
 	// TODO: Fix the ToClient configuration
-	ghs.client, err = ghs.cfg.ToClient(host, ghs.settings)
+	// ghs.client, err = ghs.cfg.ToClient(host, ghs.settings)
+	client, err := ghs.cfg.ToClient(host, ghs.settings)
+	ghs.client = common.NewWrapperClient(client)
+	// ghs.client = &common.CustomClient{UnderlyingClient: internalCLient}
 	return
 }
 

--- a/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers.go
+++ b/pkg/receiver/gitproviderreceiver/internal/scraper/githubscraper/graphql_helpers.go
@@ -159,7 +159,7 @@ func genDefaultSearchQuery(ownertype string, ghorg string) string {
 func (ghs *githubScraper) createClients() (gClient graphql.Client, rClient *github.Client, err error) {
 
 	gURL := "https://api.github.com/graphql"
-	rClient = github.NewClient(ghs.client)
+	rClient = github.NewClient(ghs.client.Client)
 
 	if ghs.cfg.HTTPClientSettings.Endpoint != "" {
 
@@ -173,7 +173,7 @@ func (ghs *githubScraper) createClients() (gClient graphql.Client, rClient *gith
 
 		// The rest client needs the endpoint to be the root of the server
 		rURL := ghs.cfg.HTTPClientSettings.Endpoint
-		rClient, err = github.NewEnterpriseClient(rURL, rURL, ghs.client)
+		rClient, err = github.NewEnterpriseClient(rURL, rURL, ghs.client.Client)
 		if err != nil {
 			ghs.logger.Sugar().Errorf("error: %v", err)
 			return nil, nil, err


### PR DESCRIPTION
This adds a rate limiter to the GitHub scraper. The rate limiter
is implemented as a Strategy Pattern. So other gitproviders can
handle their own rate limiting logic.

This also adds a client wrapper that implements the Doer
interface so we can hook into request/response headers and ultimately
the rate limiting logic.