### PR TITLE
chore(deps): update renovate config to add gomodTidy post update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,8 +70,7 @@
         "gomod"
       ],
       "matchFileNames": [
-        "internal/tools/**",
-        "go.mod"
+        "internal/tools/**"
       ],
       "groupName": "receiver component deps",
       "description": "Groups together all dependencies on receiver components"

--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
         "gomod"
       ],
       "matchFileNames": [
-        "receiver/**",
+        "internal/tools/**",
         "go.mod"
       ],
       "groupName": "receiver component deps",
@@ -86,6 +86,9 @@
       "groupName": "compgen cmd deps",
       "description": "Groups together all dependencies of the compgen utility"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ],
   "prConcurrentLimit": 10,
   "ignoreDeps": [


### PR DESCRIPTION
May look to leveraging self hosted renovate in favor of hosted due to the un-availability for the `postUpgradeOptions` command.