### PR TITLE
fix: Ignore archived projects in Gitlab scraper

### DIFF
--- a/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/helpers.go
+++ b/receiver/gitproviderreceiver/internal/scraper/gitlabscraper/helpers.go
@@ -29,6 +29,7 @@ func (gls *gitlabScraper) getProjects(restClient *gitlab.Client) ([]gitlabProjec
 			IncludeSubGroups: gitlab.Ptr(true),
 			Topic:            gitlab.Ptr(gls.cfg.SearchTopic),
 			Search:           gitlab.Ptr(gls.cfg.SearchQuery),
+			Archived:         gitlab.Ptr(false),
 			ListOptions: gitlab.ListOptions{
 				Page:    nextPage,
 				PerPage: 100,


### PR DESCRIPTION
I don't think we want to include Archived projects in Gitlab. They are read-only and will skew metrics if there are stale branches or merge requests at the time of archival. 