### PR TITLE
ci: restructure semantic release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   lint:
+    if: github.actor != 'liatrio-otel-collector-release[bot]'
     strategy:
       matrix:
         go: ['1.22']
@@ -61,6 +62,7 @@ jobs:
 
   build:
     name: build
+    if: github.actor != 'liatrio-otel-collector-release[bot]'
     strategy:
       matrix:
         GOOS: [darwin, linux, windows]
@@ -117,6 +119,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   test:
+    if: github.actor != 'liatrio-otel-collector-release[bot]'
     strategy:
       matrix:
         go: ['1.22']
@@ -140,7 +143,7 @@ jobs:
         uses: codecov/codecov-action@v4
 
   go-semantic-release:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }} || github.actor != 'liatrio-otel-collector-release[bot]'
     needs: [lint, build]
     runs-on:
       group: bigger
@@ -176,7 +179,6 @@ jobs:
           echo ${{ steps.get_next_version.outputs.version }}
           echo ${{ steps.get_next_version.outputs.hasNextVersion }}
 
-
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
@@ -195,11 +197,3 @@ jobs:
           git commit -m "chore: run multimod to update versions ahead of release(version ${{ steps.get_next_version.outputs.version }})"
           make multimod-prerelease
           git push
-
-      - name: Run go-semantic-release
-        if: steps.get_next_version.outputs.hasNextVersion == 'true'
-        uses: go-semantic-release/action@48d83acd958dae62e73701aad20a5b5844a3bf45 # v1.23.0
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          changelog-generator-opt: emojis=true
-          allow-initial-development-versions: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
 
-  go-semantic-release:
-    if: ${{ github.ref == 'refs/heads/main' }} || github.actor != 'liatrio-otel-collector-release[bot]'
+  prepare-go-semantic-release:
+    if: ${{ github.ref == 'refs/heads/main' }} && github.actor != 'liatrio-otel-collector-release[bot]'
     needs: [lint, build]
     runs-on:
       group: bigger

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: Build and Test
+name: build-and-test
 
 on:
   pull_request:
@@ -142,7 +142,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
 
-  prepare-go-semantic-release:
+  multimod-prepare-release:
     if: ${{ github.ref == 'refs/heads/main' }} && github.actor != 'liatrio-otel-collector-release[bot]'
     needs: [lint, build]
     runs-on:
@@ -191,7 +191,6 @@ jobs:
           set -eo pipefail
           git config --global user.name '${{ steps.generate_token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          # gh auth login --hostname github.com --git-protocol https --with-token <<< "${{ steps.generate_token.outputs.token }}"
           yq -i '.module-sets.liatrio-otel.version = "${{ steps.get_next_version.outputs.version }}"' versions.yaml
           git add .
           git commit -m "chore: run multimod to update versions ahead of release(version ${{ steps.get_next_version.outputs.version }})"

--- a/.github/workflows/go-semantic-release.yml
+++ b/.github/workflows/go-semantic-release.yml
@@ -3,7 +3,7 @@ name: Go Semantic Release
 
 on:
   workflow_run:
-    workflows: [Build and Test]
+    workflows: [build-and-test]
     types:
       - completed
 

--- a/.github/workflows/go-semantic-release.yml
+++ b/.github/workflows/go-semantic-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   go-semantic-release:
+    if: ${{ github.ref == 'refs/heads/main' }} && github.actor == 'liatrio-otel-collector-release[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token

--- a/.github/workflows/go-semantic-release.yml
+++ b/.github/workflows/go-semantic-release.yml
@@ -1,0 +1,37 @@
+---
+name: Go Semantic Release
+
+on:
+  workflow_run:
+    workflows: [Build and Test]
+    types:
+      - completed
+
+jobs:
+  go-semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Clone repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.22
+
+      - name: Run go-semantic-release
+        uses: go-semantic-release/action@48d83acd958dae62e73701aad20a5b5844a3bf45 # v1.23.0
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          changelog-generator-opt: emojis=true
+          allow-initial-development-versions: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.actor != 'liatrio-otel-collector-release[bot]'
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR refines the continuous integration setup by enhancing the semantic release process. 

The following changes have been made:

- Added a condition to prevent workflows triggered by pushes to the main branch from executing if the GitHub actor is not the release bot.
- Triggered the semantic release workflow to run only after the "Build and Test" workflow completes, ensuring proper sequencing of tasks.

These updates streamline the workflow and improve token handling for better security and automation control.