### PR TITLE
chore: Explicitly add defulat providers to builder config

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -61,6 +61,9 @@ connectors:
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.15.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.15.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.109.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.109.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.109.0
 
 replaces:
   - github.com/liatrio/liatrio-otel-collector/receiver/gitproviderreceiver => ../receiver/gitproviderreceiver/


### PR DESCRIPTION
This is a no-op change but should make future updates easier. 

OCB made assumptions that implied default providers matched the builder version https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/builder/internal/builder/config.go#L219-L231

This is a bad assumption as uncovered by the 1.15.0/0.109.0 release. A couple of the default providers moved to stable while others are not and the builder is still not stable. 

There has been conversations to resolve this but there is enforced strict versioning checks that make this more challenging. 

The provided advice now is to explicitly set default providers in the builder config. https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.109.0

This is a chore because currently the implied default providers match the builder version thus the latest release is good. Putting them here explicitly will ensure we update these providers as others move to stable. 