### PR TITLE
feat: add tail based and probabilistic sampling plugins 

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -39,8 +39,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor v0.111.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0

--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -41,6 +41,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.111.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0

--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -39,6 +39,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.111.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor v0.111.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor v0.111.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.111.0


### PR DESCRIPTION
This PR will add two new processor plugins, focused on sampling, to the manifest. The goal being to reduce the volume of data being sent to the collector while still keeping important data. 

1. probabilisticsamplerprocessor: This plugin will allow users to sample traces based on a probability distribution. PSP uses a configured sampling percentage to determine which traces or logs to sample. [More info here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/probabilisticsamplerprocessor/README.md)
2. tailsamplingprocessor - The Tail Sampling Processor delays the sampling decision until all spans of a trace are available, enabling better sampling decisions based on the complete trace information. [More info here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md)

Note on tail sampling - In my research I saw that it could be a rather expensive operation since it waits to make a decision to the trace is done. 