### PR TITLE
feat: Add ability to limit query for merged merge requests in gitlab

### DIFF
--- a/receiver/gitlabreceiver/README.md
+++ b/receiver/gitlabreceiver/README.md
@@ -60,6 +60,7 @@ receivers:
                         enabled: true
                 gitlab_org: myfancyorg
                 search_query: "org:myfancyorg topic:o11yalltheway" #Recommended optional query override, defaults to "{org,user}:<gitlab_org>"
+                limit_merge_requests: 30 #Limit querying merged MRs to the last 30 days, defaults to querying all historical merged MRs
                 endpoint: "https://selfmanagedenterpriseserver.com"
                 auth:
                     authenticator: bearertokenauth/gitlab

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/config.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	// GitLabOrg is the name of the GitLab organization to scrape (gitlab scraper only)
 	GitLabOrg string `mapstructure:"gitlab_org"`
 
-	SearchTopic string `mapstructure:"search_topic"`
-	SearchQuery string `mapstructure:"search_query"`
+	SearchTopic        string `mapstructure:"search_topic"`
+	SearchQuery        string `mapstructure:"search_query"`
+	LimitMergeRequests int    `mapstructure:"limit_merge_requests"`
 }

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
@@ -113,9 +113,10 @@ func (v *__getBranchNamesInput) GetFullPath() string { return v.FullPath }
 
 // __getMergeRequestsInput is used internally by genqlient
 type __getMergeRequestsInput struct {
-	FullPath string            `json:"fullPath"`
-	After    *string           `json:"after"`
-	State    MergeRequestState `json:"state"`
+	FullPath     string            `json:"fullPath"`
+	After        *string           `json:"after"`
+	State        MergeRequestState `json:"state"`
+	CreatedAfter time.Time         `json:"createdAfter"`
 }
 
 // GetFullPath returns __getMergeRequestsInput.FullPath, and is useful for accessing the field via an interface.
@@ -126,6 +127,9 @@ func (v *__getMergeRequestsInput) GetAfter() *string { return v.After }
 
 // GetState returns __getMergeRequestsInput.State, and is useful for accessing the field via an interface.
 func (v *__getMergeRequestsInput) GetState() MergeRequestState { return v.State }
+
+// GetCreatedAfter returns __getMergeRequestsInput.CreatedAfter, and is useful for accessing the field via an interface.
+func (v *__getMergeRequestsInput) GetCreatedAfter() time.Time { return v.CreatedAfter }
 
 // __getProjectsByTopicInput is used internally by genqlient
 type __getProjectsByTopicInput struct {
@@ -474,9 +478,9 @@ func getBranchNames(
 
 // The query executed by getMergeRequests.
 const getMergeRequests_Operation = `
-query getMergeRequests ($fullPath: ID!, $after: String, $state: MergeRequestState) {
+query getMergeRequests ($fullPath: ID!, $after: String, $state: MergeRequestState, $createdAfter: Time!) {
 	project(fullPath: $fullPath) {
-		mergeRequests(state: $state, after: $after) {
+		mergeRequests(state: $state, createdAfter: $createdAfter, after: $after) {
 			pageInfo {
 				hasNextPage
 				endCursor
@@ -504,14 +508,16 @@ func getMergeRequests(
 	fullPath string,
 	after *string,
 	state MergeRequestState,
+	createdAfter time.Time,
 ) (data_ *getMergeRequestsResponse, err_ error) {
 	req_ := &graphql.Request{
 		OpName: "getMergeRequests",
 		Query:  getMergeRequests_Operation,
 		Variables: &__getMergeRequestsInput{
-			FullPath: fullPath,
-			After:    after,
-			State:    state,
+			FullPath:     fullPath,
+			After:        after,
+			State:        state,
+			CreatedAfter: createdAfter,
 		},
 	}
 

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
@@ -51,9 +51,10 @@ query getMergeRequests(
   # @genqlient(pointer: true)
   $after: String
   $state: MergeRequestState
+  $createdAfter: Time!
 ) {
   project(fullPath: $fullPath) {
-    mergeRequests(state: $state, after: $after) {
+    mergeRequests(state: $state, createdAfter: $createdAfter, after: $after) {
       pageInfo {
         hasNextPage
         endCursor

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -145,7 +145,7 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			}
 
 			// Get both the merged and open merge requests for the repository
-			mrs, err := gls.getCombinedMergeRequests(ctx, graphClient, path)
+			mrs, err := gls.getCombinedMergeRequests(ctx, graphClient, path, gls.cfg.LimitMergeRequests)
 			if err != nil {
 				gls.logger.Sugar().Errorf("error getting merge requests: %v", zap.Error(err))
 				return

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
@@ -390,7 +390,7 @@ func TestGetMergeRequests(t *testing.T) {
 
 			client := graphql.NewClient(server.URL, gls.client)
 
-			mergeRequestData, err := gls.getMergeRequests(context.Background(), client, "projectPath", MergeRequestState("opened"))
+			mergeRequestData, err := gls.getMergeRequests(context.Background(), client, "projectPath", MergeRequestState("opened"), time.Time{})
 
 			assert.Equal(t, tc.expectedCount, len(mergeRequestData))
 			if tc.expectedErr != nil {

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
@@ -496,7 +496,7 @@ func TestGetCombinedMergeRequests(t *testing.T) {
 
 			client := graphql.NewClient(server.URL, gls.client)
 
-			mergeRequestData, err := gls.getCombinedMergeRequests(context.Background(), client, "projectPath")
+			mergeRequestData, err := gls.getCombinedMergeRequests(context.Background(), client, "projectPath", 0)
 
 			assert.Equal(t, tc.expectedCount, len(mergeRequestData))
 			if tc.expectedErr != nil {


### PR DESCRIPTION
When dealing with repositories with a lot of history, there could be a significant number of merged merge requests. Some repositories could have thousands or tens of thousands of merged changes in their history. This can have a significant impact on the performance of the collector and will continue to grow over time. Also, knowing the metrics for merge requests from years in the past may not be relevant or helpful compared to the more recent past. 

To help with this problem, this pull request adds the `limit_merge_requests` configuration option. With it, you can filter merged merge requests to only those created within the last X number of days. 