### PR TITLE
feat: Add rate limit retry to gitlab requests and better error messages when failures occur

### DIFF
--- a/receiver/gitlabreceiver/go.mod
+++ b/receiver/gitlabreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.23.4
 
 require (
 	github.com/Khan/genqlient v0.8.0
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -84,7 +83,7 @@ func (gls *gitlabScraper) getBranchNames(ctx context.Context, client graphql.Cli
 		branches, err = getBranchNames(ctx, client, projectPath)
 		if err != nil {
 			if apiErr, ok := err.(*gitlab.ErrorResponse); ok && apiErr.Response.StatusCode == 429 &&
-				strings.Contains(apiErr.Message, "Too many requests") {
+				apiErr.Response.Status == "429 Too Many Requests" {
 				return "", backoff.RetryAfter(60)
 			}
 			return "", backoff.Permanent(err)
@@ -107,7 +106,7 @@ func (gls *gitlabScraper) getInitialCommit(ctx context.Context, client *gitlab.C
 		diff, _, err = client.Repositories.Compare(projectPath, &gitlab.CompareOptions{From: &defaultBranch, To: &branch})
 		if err != nil {
 			if apiErr, ok := err.(*gitlab.ErrorResponse); ok && apiErr.Response.StatusCode == 429 &&
-				strings.Contains(apiErr.Message, "Too many requests") {
+				apiErr.Response.Status == "429 Too Many Requests" {
 				return "", backoff.RetryAfter(60)
 			}
 			return "", backoff.Permanent(err)
@@ -138,7 +137,7 @@ func (gls *gitlabScraper) getContributorCount(
 		contributors, _, err = restClient.Repositories.Contributors(projectPath, nil)
 		if err != nil {
 			if apiErr, ok := err.(*gitlab.ErrorResponse); ok && apiErr.Response.StatusCode == 429 &&
-				strings.Contains(apiErr.Message, "Too many requests") {
+				apiErr.Response.Status == "429 Too Many Requests" {
 				return "", backoff.RetryAfter(60)
 			}
 			return "", backoff.Permanent(err)
@@ -169,7 +168,7 @@ func (gls *gitlabScraper) getMergeRequests(
 			mr, err := getMergeRequests(ctx, graphClient, projectPath, mrCursor, state, createdAfter)
 			if err != nil {
 				if apiErr, ok := err.(*gitlab.ErrorResponse); ok && apiErr.Response.StatusCode == 429 &&
-					strings.Contains(apiErr.Message, "Too many requests") {
+					apiErr.Response.Status == "429 Too Many Requests" {
 					return "", backoff.RetryAfter(60)
 				}
 				return "", backoff.Permanent(err)

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
-	"go.uber.org/zap"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/cenkalti/backoff/v5"
@@ -149,7 +148,6 @@ func (gls *gitlabScraper) getContributorCount(
 	_, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(backoff.NewExponentialBackOff()))
 
 	if err != nil {
-		gls.logger.Sugar().Errorf("error getting contributors: %v", zap.Error(err))
 		return 0, err
 	}
 
@@ -188,7 +186,6 @@ func (gls *gitlabScraper) getMergeRequests(
 		_, err := backoff.Retry(ctx, operation, backoff.WithBackOff(backoff.NewExponentialBackOff()))
 
 		if err != nil {
-			gls.logger.Sugar().Errorf("error: %v", err)
 			return nil, err
 		}
 	}
@@ -212,12 +209,10 @@ func (gls *gitlabScraper) getCombinedMergeRequests(
 	// always grab all open MRs
 	openMrs, err := gls.getMergeRequests(ctx, graphClient, projectPath, MergeRequestStateOpened, time.Time{})
 	if err != nil {
-		gls.logger.Sugar().Errorf("error getting open merge requests: %v", zap.Error(err))
 		return nil, err
 	}
 	mergedMrs, err := gls.getMergeRequests(ctx, graphClient, projectPath, MergeRequestStateMerged, createdAfter)
 	if err != nil {
-		gls.logger.Sugar().Errorf("error getting merged merge requests: %v", zap.Error(err))
 		return nil, err
 	}
 	mrs := append(openMrs, mergedMrs...)

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
@@ -642,7 +642,7 @@ func TestGetInitialCommit(t *testing.T) {
 			defer func() { server.Close() }()
 			client, err := gitlab.NewClient("", gitlab.WithBaseURL(server.URL))
 			assert.NoError(t, err)
-			commit, err := gls.getInitialCommit(client, "project", "defaultBranch", "branch")
+			commit, err := gls.getInitialCommit(context.Background(), client, "project", "defaultBranch", "branch")
 
 			assert.Equal(t, tc.expectedCommit, commit)
 			if tc.expectedErr != nil {


### PR DESCRIPTION
When configuring the gitlab receiver to scrape a group with either a large number of repositories or repositories with many branches, the performance can be pretty slow. This was due to the nature of the function used to loop over repositories in parallel. This parallel processing was somewhat limited by the use of the mutex lock/unlock at the beginning/end of the function. This effectively single-threaded the processing of each repository. 

By adding more precise lock/unlock calls it allows more parallel processing to occur and only lock execution when updating the metric builder. However, in allowing more parallel calls to be made for each repo, we quickly ran into rate limiting errors from the Gitlab API. I tried to mimic the rate limiting handling already implemented within the github receiver, however there is no rate limit information provided from the gitlab graphql api like github, so the backoff simply waits for 60 seconds (rate limiting is per minute in gitlab) and tries again. 

Tested this successfully on several large groups within gitlab with dozens of repositories that contain thousands of branches collectively. 