### PR TITLE
fix: Add rate limit retry logic for gitlab getProjects function

### DIFF
--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -94,7 +94,7 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		gls.logger.Sugar().Errorf("error: %v", err)
 	}
 
-	projectList, err := gls.getProjects(restClient)
+	projectList, err := gls.getProjects(ctx, restClient)
 	if err != nil {
 		gls.logger.Sugar().Errorf("error: %v", err)
 		return gls.mb.Emit(), err

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/liatrio/liatrio-otel-collector/receiver/gitlabreceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
@@ -52,7 +53,7 @@ func TestScrape(t *testing.T) {
 				},
 			}),
 			testFile:    "expected_no_projects.yaml",
-			expectedErr: errors.New("no GitLab projects found for the given group/org: project"),
+			expectedErr: backoff.Permanent(errors.New("no GitLab projects found for the given group/org: project")),
 		},
 		{
 			desc: "Happy Path",

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers_test.go
@@ -209,7 +209,7 @@ func TestGetProjects(t *testing.T) {
 			gls.cfg.GitLabOrg = "project"
 			client, err := gitlab.NewClient("", gitlab.WithBaseURL(server.URL))
 			assert.NoError(t, err)
-			projects, err := gls.getProjects(client)
+			projects, err := gls.getProjects(context.Background(), client)
 
 			assert.Equal(t, tc.expectedCount, len(projects))
 			if tc.expectedErr != nil {


### PR DESCRIPTION
I should have added the retry logic to the getProjects as well. I figured it was early enough in the process that it wouldn't be subjected to rate limiting. If you have multiple receivers configured to scrape multiple gitlab groups in parallel it's possible for one receiver to start making a large number of API calls. At that point, subsequent receivers could still fail on the initial API call to retrieve projects. 