### PR TITLE
chore: Update manifest

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -13,7 +13,7 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.122.0
-  - gomod: github.com/liatrio/liatrio-otel-collector/extension/githubappauthextension v0.52.0
+  - gomod: github.com/liatrio/liatrio-otel-collector/extension/githubappauthextension v0.90.1
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
@@ -31,7 +31,7 @@ exporters:
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.122.0
@@ -45,10 +45,10 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor v0.122.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
-  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/gitlabreceiver v0.72.0
-  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/githubreceiver v0.72.0
-  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/githubactionsreceiver v0.72.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.124.0
+  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/gitlabreceiver v0.90.1
+  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/githubreceiver v0.90.1
+  - gomod: github.com/liatrio/liatrio-otel-collector/receiver/githubactionsreceiver v0.90.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.122.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.122.0
@@ -81,3 +81,13 @@ replaces:
   - golang.org/x/oauth2 => golang.org/x/oauth2 v0.27.0
   - github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.55.0
   - github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.0
+  - go.opentelemetry.io/collector => go.opentelemetry.io/collector v0.124.0
+  - go.opentelemetry.io/collector/exporter => go.opentelemetry.io/collector/exporter v0.122.1
+  - go.opentelemetry.io/collector/extension => go.opentelemetry.io/collector/extension v1.30.0
+  - go.opentelemetry.io/collector/processor => go.opentelemetry.io/collector/processor v1.30.0
+  - go.opentelemetry.io/collector/receiver => go.opentelemetry.io/collector/receiver v1.30.0
+  - go.opentelemetry.io/collector/connector => go.opentelemetry.io/collector/connector v0.124.0
+  - go.opentelemetry.io/collector/config => go.opentelemetry.io/collector/config v1.30.0
+  - go.opentelemetry.io/collector/extension/extensionauth => go.opentelemetry.io/collector/extension/extensionauth v0.122.1
+  - go.opentelemetry.io/collector/confmap => go.opentelemetry.io/collector/confmap v1.26.0
+  - go.opentelemetry.io/collector/service => go.opentelemetry.io/collector/service v0.124.0


### PR DESCRIPTION
Updating manifest to use up-to-date component versions that are necessary for some upstream changes we are porting back