### PR TITLE
feat: Add project ID to gitlab attributes and include concurrency limit

### DIFF
--- a/receiver/gitlabreceiver/documentation.md
+++ b/receiver/gitlabreceiver/documentation.md
@@ -27,6 +27,7 @@ The number of changes (pull requests) in a repository, categorized by their stat
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 
 ### vcs.change.duration
 
@@ -42,6 +43,7 @@ The time duration a change (pull request/merge request/changelist) has been in a
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 | vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` |
 
@@ -59,6 +61,7 @@ The amount of time it took a change (pull request) to go from open to approved.
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 
 ### vcs.change.time_to_merge
@@ -75,6 +78,7 @@ The amount of time it took a change (pull request) to go from open to merged.
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 
 ### vcs.ref.count
@@ -91,6 +95,7 @@ The number of refs of type branch in a repository.
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` |
 
 ### vcs.ref.lines_delta
@@ -107,6 +112,7 @@ The number of lines added/removed in a ref (branch) relative to the default bran
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 | vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` |
 | vcs.line_change.type | The type of line change being measured on a ref (branch). | Str: ``added``, ``removed`` |
@@ -125,6 +131,7 @@ The number of revisions (commits) a ref (branch) is ahead/behind the branch from
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 | vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` |
 | vcs.revision_delta.direction | The type of revision comparison. | Str: ``ahead``, ``behind`` |
@@ -143,6 +150,7 @@ Time a ref (branch) created from the default branch (trunk) has existed. The `vc
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 | vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str |
 | vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` |
 
@@ -178,6 +186,7 @@ The number of unique contributors to a repository.
 | ---- | ----------- | ------ |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str |
 | vcs.repository.name | The name of the VCS repository. | Any Str |
+| vcs.repository.id | The unique identifier of the VCS repository. | Any Str |
 
 ## Resource Attributes
 

--- a/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
@@ -132,7 +132,7 @@ func (m *metricVcsChangeCount) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsChangeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsChangeStateAttributeValue string, vcsRepositoryNameAttributeValue string) {
+func (m *metricVcsChangeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsChangeStateAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -143,6 +143,7 @@ func (m *metricVcsChangeCount) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -185,7 +186,7 @@ func (m *metricVcsChangeDuration) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsChangeDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsChangeStateAttributeValue string) {
+func (m *metricVcsChangeDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsChangeStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -195,6 +196,7 @@ func (m *metricVcsChangeDuration) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 	dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
 }
@@ -239,7 +241,7 @@ func (m *metricVcsChangeTimeToApproval) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsChangeTimeToApproval) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
+func (m *metricVcsChangeTimeToApproval) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -249,6 +251,7 @@ func (m *metricVcsChangeTimeToApproval) recordDataPoint(start pcommon.Timestamp,
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 }
 
@@ -292,7 +295,7 @@ func (m *metricVcsChangeTimeToMerge) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsChangeTimeToMerge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
+func (m *metricVcsChangeTimeToMerge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -302,6 +305,7 @@ func (m *metricVcsChangeTimeToMerge) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 }
 
@@ -345,7 +349,7 @@ func (m *metricVcsContributorCount) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsContributorCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string) {
+func (m *metricVcsContributorCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -355,6 +359,7 @@ func (m *metricVcsContributorCount) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -397,7 +402,7 @@ func (m *metricVcsRefCount) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsRefCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadTypeAttributeValue string) {
+func (m *metricVcsRefCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -407,6 +412,7 @@ func (m *metricVcsRefCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
 }
 
@@ -450,7 +456,7 @@ func (m *metricVcsRefLinesDelta) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsLineChangeTypeAttributeValue string) {
+func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsLineChangeTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -460,6 +466,7 @@ func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
 	dp.Attributes().PutStr("vcs.line_change.type", vcsLineChangeTypeAttributeValue)
@@ -505,7 +512,7 @@ func (m *metricVcsRefRevisionsDelta) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsRefRevisionsDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsRevisionDeltaDirectionAttributeValue string) {
+func (m *metricVcsRefRevisionsDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsRevisionDeltaDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -515,6 +522,7 @@ func (m *metricVcsRefRevisionsDelta) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
 	dp.Attributes().PutStr("vcs.revision_delta.direction", vcsRevisionDeltaDirectionAttributeValue)
@@ -560,7 +568,7 @@ func (m *metricVcsRefTime) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcsRefTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string) {
+func (m *metricVcsRefTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -570,6 +578,7 @@ func (m *metricVcsRefTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.T
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	dp.Attributes().PutStr("vcs.repository.id", vcsRepositoryIDAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
 	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
 }
@@ -830,48 +839,48 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordVcsChangeCountDataPoint adds a data point to vcs.change.count metric.
-func (mb *MetricsBuilder) RecordVcsChangeCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsChangeStateAttributeValue AttributeVcsChangeState, vcsRepositoryNameAttributeValue string) {
-	mb.metricVcsChangeCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsChangeStateAttributeValue.String(), vcsRepositoryNameAttributeValue)
+func (mb *MetricsBuilder) RecordVcsChangeCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsChangeStateAttributeValue AttributeVcsChangeState, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string) {
+	mb.metricVcsChangeCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsChangeStateAttributeValue.String(), vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue)
 }
 
 // RecordVcsChangeDurationDataPoint adds a data point to vcs.change.duration metric.
-func (mb *MetricsBuilder) RecordVcsChangeDurationDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsChangeStateAttributeValue AttributeVcsChangeState) {
-	mb.metricVcsChangeDuration.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue, vcsChangeStateAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsChangeDurationDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsChangeStateAttributeValue AttributeVcsChangeState) {
+	mb.metricVcsChangeDuration.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsChangeStateAttributeValue.String())
 }
 
 // RecordVcsChangeTimeToApprovalDataPoint adds a data point to vcs.change.time_to_approval metric.
-func (mb *MetricsBuilder) RecordVcsChangeTimeToApprovalDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
-	mb.metricVcsChangeTimeToApproval.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue)
+func (mb *MetricsBuilder) RecordVcsChangeTimeToApprovalDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string) {
+	mb.metricVcsChangeTimeToApproval.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue)
 }
 
 // RecordVcsChangeTimeToMergeDataPoint adds a data point to vcs.change.time_to_merge metric.
-func (mb *MetricsBuilder) RecordVcsChangeTimeToMergeDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
-	mb.metricVcsChangeTimeToMerge.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue)
+func (mb *MetricsBuilder) RecordVcsChangeTimeToMergeDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string) {
+	mb.metricVcsChangeTimeToMerge.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue)
 }
 
 // RecordVcsContributorCountDataPoint adds a data point to vcs.contributor.count metric.
-func (mb *MetricsBuilder) RecordVcsContributorCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string) {
-	mb.metricVcsContributorCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue)
+func (mb *MetricsBuilder) RecordVcsContributorCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string) {
+	mb.metricVcsContributorCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue)
 }
 
 // RecordVcsRefCountDataPoint adds a data point to vcs.ref.count metric.
-func (mb *MetricsBuilder) RecordVcsRefCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType) {
-	mb.metricVcsRefCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadTypeAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsRefCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType) {
+	mb.metricVcsRefCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadTypeAttributeValue.String())
 }
 
 // RecordVcsRefLinesDeltaDataPoint adds a data point to vcs.ref.lines_delta metric.
-func (mb *MetricsBuilder) RecordVcsRefLinesDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsLineChangeTypeAttributeValue AttributeVcsLineChangeType) {
-	mb.metricVcsRefLinesDelta.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsLineChangeTypeAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsRefLinesDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsLineChangeTypeAttributeValue AttributeVcsLineChangeType) {
+	mb.metricVcsRefLinesDelta.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsLineChangeTypeAttributeValue.String())
 }
 
 // RecordVcsRefRevisionsDeltaDataPoint adds a data point to vcs.ref.revisions_delta metric.
-func (mb *MetricsBuilder) RecordVcsRefRevisionsDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsRevisionDeltaDirectionAttributeValue AttributeVcsRevisionDeltaDirection) {
-	mb.metricVcsRefRevisionsDelta.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsRevisionDeltaDirectionAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsRefRevisionsDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsRevisionDeltaDirectionAttributeValue AttributeVcsRevisionDeltaDirection) {
+	mb.metricVcsRefRevisionsDelta.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsRevisionDeltaDirectionAttributeValue.String())
 }
 
 // RecordVcsRefTimeDataPoint adds a data point to vcs.ref.time metric.
-func (mb *MetricsBuilder) RecordVcsRefTimeDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType) {
-	mb.metricVcsRefTime.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsRefTimeDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType) {
+	mb.metricVcsRefTime.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String())
 }
 
 // RecordVcsRepositoryCountDataPoint adds a data point to vcs.repository.count metric.

--- a/receiver/gitlabreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_metrics_test.go
@@ -70,38 +70,38 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsChangeCountDataPoint(ts, 1, "vcs.repository.url.full-val", AttributeVcsChangeStateOpen, "vcs.repository.name-val")
+			mb.RecordVcsChangeCountDataPoint(ts, 1, "vcs.repository.url.full-val", AttributeVcsChangeStateOpen, "vcs.repository.name-val", "vcs.repository.id-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsChangeDurationDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsChangeStateOpen)
+			mb.RecordVcsChangeDurationDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsChangeStateOpen)
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsChangeTimeToApprovalDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			mb.RecordVcsChangeTimeToApprovalDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsChangeTimeToMergeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			mb.RecordVcsChangeTimeToMergeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val")
 
 			allMetricsCount++
-			mb.RecordVcsContributorCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val")
-
-			defaultMetricsCount++
-			allMetricsCount++
-			mb.RecordVcsRefCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", AttributeVcsRefHeadTypeBranch)
+			mb.RecordVcsContributorCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsRefLinesDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsLineChangeTypeAdded)
+			mb.RecordVcsRefCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", AttributeVcsRefHeadTypeBranch)
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsRefRevisionsDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsRevisionDeltaDirectionAhead)
+			mb.RecordVcsRefLinesDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsLineChangeTypeAdded)
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsRefTimeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch)
+			mb.RecordVcsRefRevisionsDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsRevisionDeltaDirectionAhead)
+
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordVcsRefTimeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -153,6 +153,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 				case "vcs.change.duration":
 					assert.False(t, validatedMetrics["vcs.change.duration"], "Found a duplicate in the metrics slice: vcs.change.duration")
 					validatedMetrics["vcs.change.duration"] = true
@@ -171,6 +174,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())
@@ -195,6 +201,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())
@@ -216,6 +225,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())
@@ -237,6 +249,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 				case "vcs.ref.count":
 					assert.False(t, validatedMetrics["vcs.ref.count"], "Found a duplicate in the metrics slice: vcs.ref.count")
 					validatedMetrics["vcs.ref.count"] = true
@@ -255,6 +270,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
 					assert.True(t, ok)
 					assert.EqualValues(t, "branch", attrVal.Str())
@@ -276,6 +294,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())
@@ -303,6 +324,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())
@@ -330,6 +354,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.repository.name-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("vcs.repository.id")
+					assert.True(t, ok)
+					assert.EqualValues(t, "vcs.repository.id-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "vcs.ref.head.name-val", attrVal.Str())

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/config.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/config.go
@@ -21,4 +21,5 @@ type Config struct {
 	SearchTopic        string `mapstructure:"search_topic"`
 	SearchQuery        string `mapstructure:"search_query"`
 	LimitMergeRequests int    `mapstructure:"limit_merge_requests"`
+	ConcurrencyLimit   int    `mapstructure:"concurrency_limit"`
 }

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
@@ -131,18 +131,6 @@ func (v *__getMergeRequestsInput) GetState() MergeRequestState { return v.State 
 // GetCreatedAfter returns __getMergeRequestsInput.CreatedAfter, and is useful for accessing the field via an interface.
 func (v *__getMergeRequestsInput) GetCreatedAfter() time.Time { return v.CreatedAfter }
 
-// __getProjectsByTopicInput is used internally by genqlient
-type __getProjectsByTopicInput struct {
-	Org    string   `json:"org"`
-	Topics []string `json:"topics"`
-}
-
-// GetOrg returns __getProjectsByTopicInput.Org, and is useful for accessing the field via an interface.
-func (v *__getProjectsByTopicInput) GetOrg() string { return v.Org }
-
-// GetTopics returns __getProjectsByTopicInput.Topics, and is useful for accessing the field via an interface.
-func (v *__getProjectsByTopicInput) GetTopics() []string { return v.Topics }
-
 // getAllGroupProjectsGroup includes the requested fields of the GraphQL type Group.
 type getAllGroupProjectsGroup struct {
 	// Projects within this namespace.
@@ -184,6 +172,8 @@ func (v *getAllGroupProjectsGroupProjectsProjectConnection) GetNodes() []getAllG
 type getAllGroupProjectsGroupProjectsProjectConnectionNodesProject struct {
 	// Name of the project (without namespace).
 	Name string `json:"name"`
+	// ID of the project.
+	Id string `json:"id"`
 	// Full path of the project.
 	FullPath string `json:"fullPath"`
 	// Timestamp of the project creation.
@@ -196,6 +186,9 @@ type getAllGroupProjectsGroupProjectsProjectConnectionNodesProject struct {
 func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetName() string {
 	return v.Name
 }
+
+// GetId returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.Id, and is useful for accessing the field via an interface.
+func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetId() string { return v.Id }
 
 // GetFullPath returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.FullPath, and is useful for accessing the field via an interface.
 func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetFullPath() string {
@@ -336,61 +329,6 @@ type getMergeRequestsResponse struct {
 // GetProject returns getMergeRequestsResponse.Project, and is useful for accessing the field via an interface.
 func (v *getMergeRequestsResponse) GetProject() getMergeRequestsProject { return v.Project }
 
-// getProjectsByTopicProjectsProjectConnection includes the requested fields of the GraphQL type ProjectConnection.
-// The GraphQL type's documentation follows.
-//
-// The connection type for Project.
-type getProjectsByTopicProjectsProjectConnection struct {
-	// A list of nodes.
-	Nodes []getProjectsByTopicProjectsProjectConnectionNodesProject `json:"nodes"`
-}
-
-// GetNodes returns getProjectsByTopicProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnection) GetNodes() []getProjectsByTopicProjectsProjectConnectionNodesProject {
-	return v.Nodes
-}
-
-// getProjectsByTopicProjectsProjectConnectionNodesProject includes the requested fields of the GraphQL type Project.
-type getProjectsByTopicProjectsProjectConnectionNodesProject struct {
-	// Name of the project (without namespace).
-	Name string `json:"name"`
-	// Full path of the project.
-	FullPath string `json:"fullPath"`
-	// Timestamp of the project creation.
-	CreatedAt time.Time `json:"createdAt"`
-	// Timestamp of the project last activity.
-	LastActivityAt time.Time `json:"lastActivityAt"`
-}
-
-// GetName returns getProjectsByTopicProjectsProjectConnectionNodesProject.Name, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetName() string { return v.Name }
-
-// GetFullPath returns getProjectsByTopicProjectsProjectConnectionNodesProject.FullPath, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetFullPath() string {
-	return v.FullPath
-}
-
-// GetCreatedAt returns getProjectsByTopicProjectsProjectConnectionNodesProject.CreatedAt, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetCreatedAt() time.Time {
-	return v.CreatedAt
-}
-
-// GetLastActivityAt returns getProjectsByTopicProjectsProjectConnectionNodesProject.LastActivityAt, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicProjectsProjectConnectionNodesProject) GetLastActivityAt() time.Time {
-	return v.LastActivityAt
-}
-
-// getProjectsByTopicResponse is returned by getProjectsByTopic on success.
-type getProjectsByTopicResponse struct {
-	// Find projects visible to the current user.
-	Projects getProjectsByTopicProjectsProjectConnection `json:"projects"`
-}
-
-// GetProjects returns getProjectsByTopicResponse.Projects, and is useful for accessing the field via an interface.
-func (v *getProjectsByTopicResponse) GetProjects() getProjectsByTopicProjectsProjectConnection {
-	return v.Projects
-}
-
 // The query executed by getAllGroupProjects.
 const getAllGroupProjects_Operation = `
 query getAllGroupProjects ($fullPath: ID!, $after: String) {
@@ -403,6 +341,7 @@ query getAllGroupProjects ($fullPath: ID!, $after: String) {
 			}
 			nodes {
 				name
+				id
 				fullPath
 				createdAt
 				lastActivityAt
@@ -522,47 +461,6 @@ func getMergeRequests(
 	}
 
 	data_ = &getMergeRequestsResponse{}
-	resp_ := &graphql.Response{Data: data_}
-
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
-	)
-
-	return data_, err_
-}
-
-// The query executed by getProjectsByTopic.
-const getProjectsByTopic_Operation = `
-query getProjectsByTopic ($org: String!, $topics: [String!]) {
-	projects(searchNamespaces: true, search: $org, topics: $topics) {
-		nodes {
-			name
-			fullPath
-			createdAt
-			lastActivityAt
-		}
-	}
-}
-`
-
-func getProjectsByTopic(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	org string,
-	topics []string,
-) (data_ *getProjectsByTopicResponse, err_ error) {
-	req_ := &graphql.Request{
-		OpName: "getProjectsByTopic",
-		Query:  getProjectsByTopic_Operation,
-		Variables: &__getProjectsByTopicInput{
-			Org:    org,
-			Topics: topics,
-		},
-	}
-
-	data_ = &getProjectsByTopicResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/generated.go
@@ -91,18 +91,6 @@ var AllMergeRequestState = []MergeRequestState{
 	MergeRequestStateAll,
 }
 
-// __getAllGroupProjectsInput is used internally by genqlient
-type __getAllGroupProjectsInput struct {
-	FullPath string  `json:"fullPath"`
-	After    *string `json:"after"`
-}
-
-// GetFullPath returns __getAllGroupProjectsInput.FullPath, and is useful for accessing the field via an interface.
-func (v *__getAllGroupProjectsInput) GetFullPath() string { return v.FullPath }
-
-// GetAfter returns __getAllGroupProjectsInput.After, and is useful for accessing the field via an interface.
-func (v *__getAllGroupProjectsInput) GetAfter() *string { return v.After }
-
 // __getBranchNamesInput is used internally by genqlient
 type __getBranchNamesInput struct {
 	FullPath string `json:"fullPath"`
@@ -130,110 +118,6 @@ func (v *__getMergeRequestsInput) GetState() MergeRequestState { return v.State 
 
 // GetCreatedAfter returns __getMergeRequestsInput.CreatedAfter, and is useful for accessing the field via an interface.
 func (v *__getMergeRequestsInput) GetCreatedAfter() time.Time { return v.CreatedAfter }
-
-// getAllGroupProjectsGroup includes the requested fields of the GraphQL type Group.
-type getAllGroupProjectsGroup struct {
-	// Projects within this namespace.
-	Projects getAllGroupProjectsGroupProjectsProjectConnection `json:"projects"`
-}
-
-// GetProjects returns getAllGroupProjectsGroup.Projects, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroup) GetProjects() getAllGroupProjectsGroupProjectsProjectConnection {
-	return v.Projects
-}
-
-// getAllGroupProjectsGroupProjectsProjectConnection includes the requested fields of the GraphQL type ProjectConnection.
-// The GraphQL type's documentation follows.
-//
-// The connection type for Project.
-type getAllGroupProjectsGroupProjectsProjectConnection struct {
-	// Total count of collection.
-	Count int `json:"count"`
-	// Information to aid in pagination.
-	PageInfo getAllGroupProjectsGroupProjectsProjectConnectionPageInfo `json:"pageInfo"`
-	// A list of nodes.
-	Nodes []getAllGroupProjectsGroupProjectsProjectConnectionNodesProject `json:"nodes"`
-}
-
-// GetCount returns getAllGroupProjectsGroupProjectsProjectConnection.Count, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnection) GetCount() int { return v.Count }
-
-// GetPageInfo returns getAllGroupProjectsGroupProjectsProjectConnection.PageInfo, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnection) GetPageInfo() getAllGroupProjectsGroupProjectsProjectConnectionPageInfo {
-	return v.PageInfo
-}
-
-// GetNodes returns getAllGroupProjectsGroupProjectsProjectConnection.Nodes, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnection) GetNodes() []getAllGroupProjectsGroupProjectsProjectConnectionNodesProject {
-	return v.Nodes
-}
-
-// getAllGroupProjectsGroupProjectsProjectConnectionNodesProject includes the requested fields of the GraphQL type Project.
-type getAllGroupProjectsGroupProjectsProjectConnectionNodesProject struct {
-	// Name of the project (without namespace).
-	Name string `json:"name"`
-	// ID of the project.
-	Id string `json:"id"`
-	// Full path of the project.
-	FullPath string `json:"fullPath"`
-	// Timestamp of the project creation.
-	CreatedAt time.Time `json:"createdAt"`
-	// Timestamp of the project last activity.
-	LastActivityAt time.Time `json:"lastActivityAt"`
-}
-
-// GetName returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.Name, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetName() string {
-	return v.Name
-}
-
-// GetId returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.Id, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetId() string { return v.Id }
-
-// GetFullPath returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.FullPath, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetFullPath() string {
-	return v.FullPath
-}
-
-// GetCreatedAt returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.CreatedAt, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetCreatedAt() time.Time {
-	return v.CreatedAt
-}
-
-// GetLastActivityAt returns getAllGroupProjectsGroupProjectsProjectConnectionNodesProject.LastActivityAt, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionNodesProject) GetLastActivityAt() time.Time {
-	return v.LastActivityAt
-}
-
-// getAllGroupProjectsGroupProjectsProjectConnectionPageInfo includes the requested fields of the GraphQL type PageInfo.
-// The GraphQL type's documentation follows.
-//
-// Information about pagination in a connection.
-type getAllGroupProjectsGroupProjectsProjectConnectionPageInfo struct {
-	// When paginating forwards, are there more items?
-	HasNextPage bool `json:"hasNextPage"`
-	// When paginating forwards, the cursor to continue.
-	EndCursor string `json:"endCursor"`
-}
-
-// GetHasNextPage returns getAllGroupProjectsGroupProjectsProjectConnectionPageInfo.HasNextPage, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionPageInfo) GetHasNextPage() bool {
-	return v.HasNextPage
-}
-
-// GetEndCursor returns getAllGroupProjectsGroupProjectsProjectConnectionPageInfo.EndCursor, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsGroupProjectsProjectConnectionPageInfo) GetEndCursor() string {
-	return v.EndCursor
-}
-
-// getAllGroupProjectsResponse is returned by getAllGroupProjects on success.
-type getAllGroupProjectsResponse struct {
-	// Find a group.
-	Group getAllGroupProjectsGroup `json:"group"`
-}
-
-// GetGroup returns getAllGroupProjectsResponse.Group, and is useful for accessing the field via an interface.
-func (v *getAllGroupProjectsResponse) GetGroup() getAllGroupProjectsGroup { return v.Group }
 
 // getBranchNamesProject includes the requested fields of the GraphQL type Project.
 type getBranchNamesProject struct {
@@ -328,55 +212,6 @@ type getMergeRequestsResponse struct {
 
 // GetProject returns getMergeRequestsResponse.Project, and is useful for accessing the field via an interface.
 func (v *getMergeRequestsResponse) GetProject() getMergeRequestsProject { return v.Project }
-
-// The query executed by getAllGroupProjects.
-const getAllGroupProjects_Operation = `
-query getAllGroupProjects ($fullPath: ID!, $after: String) {
-	group(fullPath: $fullPath) {
-		projects(includeSubgroups: true, after: $after) {
-			count
-			pageInfo {
-				hasNextPage
-				endCursor
-			}
-			nodes {
-				name
-				id
-				fullPath
-				createdAt
-				lastActivityAt
-			}
-		}
-	}
-}
-`
-
-func getAllGroupProjects(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	fullPath string,
-	after *string,
-) (data_ *getAllGroupProjectsResponse, err_ error) {
-	req_ := &graphql.Request{
-		OpName: "getAllGroupProjects",
-		Query:  getAllGroupProjects_Operation,
-		Variables: &__getAllGroupProjectsInput{
-			FullPath: fullPath,
-			After:    after,
-		},
-	}
-
-	data_ = &getAllGroupProjectsResponse{}
-	resp_ := &graphql.Response{Data: data_}
-
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
-	)
-
-	return data_, err_
-}
 
 // The query executed by getBranchNames.
 const getBranchNames_Operation = `

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
@@ -1,28 +1,3 @@
-query getAllGroupProjects(
-  $fullPath: ID!,
-  # @genqlient(pointer: true)
-  $after: String
-) {
-  group(fullPath: $fullPath) {
-    projects(includeSubgroups: true, after: $after) {
-      count
-
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-
-      nodes {
-        name
-        id
-        fullPath
-        createdAt
-        lastActivityAt
-      }
-    }
-  }
-}
-
 query getBranchNames($fullPath: ID!) {
   project(fullPath: $fullPath) {
     repository {

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/genqlient.graphql
@@ -14,21 +14,11 @@ query getAllGroupProjects(
 
       nodes {
         name
+        id
         fullPath
         createdAt
         lastActivityAt
       }
-    }
-  }
-}
-
-query getProjectsByTopic($org: String!, $topics: [String!]) {
-  projects(searchNamespaces: true, search: $org, topics: $topics) {
-    nodes {
-      name
-      fullPath
-      createdAt
-      lastActivityAt
     }
   }
 }

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -111,7 +111,8 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	case gls.cfg.ConcurrencyLimit > 0:
 		max = gls.cfg.ConcurrencyLimit
 	default:
-		max = len(projectList)
+		// We add the 1 on here to avoid a deadlock when the number of projects is 0.
+		max = len(projectList) + 1
 	}
 
 	limiter := make(chan struct{}, max)

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper_test.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper_test.go
@@ -62,6 +62,7 @@ func TestScrape(t *testing.T) {
 					projects: []*gitlab.Project{
 						{
 							Name:              "project",
+							ID:                1,
 							PathWithNamespace: "project",
 							CreatedAt:         gitlab.Ptr(time.Now().AddDate(0, 0, -1)),
 							LastActivityAt:    gitlab.Ptr(time.Now().AddDate(0, 0, -1)),

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/helpers.go
@@ -15,6 +15,7 @@ import (
 
 type gitlabProject struct {
 	Name           string
+	ID             string
 	Path           string
 	CreatedAt      time.Time
 	LastActivityAt time.Time
@@ -54,6 +55,7 @@ func (gls *gitlabScraper) getProjects(ctx context.Context, restClient *gitlab.Cl
 			for _, p := range projects {
 				projectList = append(projectList, gitlabProject{
 					Name:           p.Name,
+					ID:             strconv.Itoa(p.ID),
 					Path:           p.PathWithNamespace,
 					CreatedAt:      *p.CreatedAt,
 					LastActivityAt: *p.LastActivityAt,

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
@@ -24,6 +24,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -40,6 +43,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -58,6 +64,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -71,6 +80,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -89,6 +101,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -113,6 +128,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -132,6 +150,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -151,6 +172,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -170,6 +194,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -189,6 +216,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -208,6 +238,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -227,6 +260,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -246,6 +282,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""
@@ -267,6 +306,9 @@ resourceMetrics:
                     - key: vcs.repository.name
                       value:
                         stringValue: project
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.repository.url.full
                       value:
                         stringValue: ""

--- a/receiver/gitlabreceiver/metadata.yaml
+++ b/receiver/gitlabreceiver/metadata.yaml
@@ -26,6 +26,9 @@ attributes:
   vcs.repository.name:
     description: The name of the VCS repository.
     type: string
+  vcs.repository.id:
+    description: The unique identifier of the VCS repository.
+    type: string
   vcs.ref.head.name:
     description: The name of the VCS head reference (branch).
     type: string
@@ -69,7 +72,7 @@ metrics:
     gauge:
       value_type: int
     attributes:
-      [vcs.repository.url.full, vcs.repository.name, vcs.ref.head.type]
+      [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.type]
   vcs.ref.time:
     enabled: true
     description: Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.head.type` attribute will always be `branch`.
@@ -80,6 +83,7 @@ metrics:
       [
         vcs.repository.url.full,
         vcs.repository.name,
+        vcs.repository.id,
         vcs.ref.head.name,
         vcs.ref.head.type,
       ]
@@ -93,6 +97,7 @@ metrics:
       [
         vcs.repository.url.full,
         vcs.repository.name,
+        vcs.repository.id,
         vcs.ref.head.name,
         vcs.ref.head.type,
         vcs.revision_delta.direction,
@@ -107,6 +112,7 @@ metrics:
       [
         vcs.repository.url.full,
         vcs.repository.name,
+        vcs.repository.id,
         vcs.ref.head.name,
         vcs.ref.head.type,
         vcs.line_change.type,
@@ -117,7 +123,7 @@ metrics:
     unit: "{contributor}"
     gauge:
       value_type: int
-    attributes: [vcs.repository.url.full, vcs.repository.name]
+    attributes: [vcs.repository.url.full, vcs.repository.name, vcs.repository.id]
   vcs.change.duration:
     enabled: true
     description: The time duration a change (pull request/merge request/changelist) has been in an open state.
@@ -128,6 +134,7 @@ metrics:
       [
         vcs.repository.url.full,
         vcs.repository.name,
+        vcs.repository.id,
         vcs.ref.head.name,
         vcs.change.state,
       ]
@@ -138,7 +145,7 @@ metrics:
     gauge:
       value_type: int
     attributes:
-      [vcs.repository.url.full, vcs.repository.name, vcs.ref.head.name]
+      [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name]
   vcs.change.time_to_approval:
     enabled: true
     description: The amount of time it took a change (pull request) to go from open to approved.
@@ -146,14 +153,14 @@ metrics:
     gauge:
       value_type: int
     attributes:
-      [vcs.repository.url.full, vcs.repository.name, vcs.ref.head.name]
+      [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name]
   vcs.change.count:
     description: The number of changes (pull requests) in a repository, categorized by their state (either open or merged).
     enabled: true
     gauge:
       value_type: int
     unit: "{change}"
-    attributes: [vcs.repository.url.full, vcs.change.state, vcs.repository.name]
+    attributes: [vcs.repository.url.full, vcs.change.state, vcs.repository.name, vcs.repository.id]
 
 tests:
   config:


### PR DESCRIPTION
Two main changes in this pull request:

1. The `vcs.repository.id` was added as an attribute to the relevant GitLab receiver metrics. This represents the unique, numerical ID for the repository. This is especially useful for any downstream processes that need to make GitLab API calls to enrich the data. Most API calls are based on the numerical ID as opposed to the string namespace. 
2. The limiter functionality from the github receiver was added to the gitlab receiver. This is useful in limiting the concurrent number of API calls being made to GitLab. By specifying the `concurrency_limit` option, you limit the number of GitLab projects that can be processed in parallel. 