### PR TITLE
fix: Remove pipeline code that commits changes and remove octo token …

### DIFF
--- a/.github/chainguard/pr-lint-format.sts.yaml
+++ b/.github/chainguard/pr-lint-format.sts.yaml
@@ -1,6 +1,0 @@
-issuer: https://token.actions.githubusercontent.com
-subject_pattern: "repo:liatrio/liatrio-otel-collector:.*"
-
-permissions:
-  contents: write
-  packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,22 +29,10 @@ jobs:
         go: ["1.23"]
     name: lint
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
     steps:
-      - name: Get Octo STS Token
-        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
-        id: octo-sts
-        with:
-          scope: ${{ github.repository }}
-          identity: pr-lint-format
-
       - name: Clone repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
@@ -64,73 +52,25 @@ jobs:
         run: |
           make generate
           if ! git diff --quiet; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Generated code is out of date. Changes detected."
-              echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            else
-              echo "Generated code is out of date. Run make generate and commit the changes."
-              exit 1
-            fi
+            echo "Generated code is out of date. Run make generate and commit the changes."
+            exit 1
           fi
 
       - name: Check Packages Are Up-to-Date
         run: |
           make tidy-all
           if ! git diff --quiet; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Packages are out of date. Changes detected."
-              echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            else
-              echo "Packages are out of date. Run make tidy-all and commit the changes."
-              exit 1
-            fi
+            echo "Packages are out of date. Run make tidy-all and commit the changes."
+            exit 1
           fi
 
       - name: Check Crosslink Run
         run: |
           make crosslink
           if ! git diff --quiet; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Replace statements not updated. Changes detected."
-              echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            else
-              echo "Replace statements not updated. Run make crosslink and commit the changes."
-              exit 1
-            fi
+            echo "Replace statements not updated. Run make crosslink and commit the changes."
+            exit 1
           fi
-
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/octo-sts[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-
-      - name: Commit changes
-        if: env.CHANGES_DETECTED == 'true' && github.event_name == 'pull_request'
-        run: |
-          set -eo pipefail
-          git config --global user.name 'octo-sts[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+octo-sts[bot]@users.noreply.github.com'
-          git add .
-          git commit -m "chore: Auto-update generated files"
-          git push origin HEAD:refs/heads/${{ github.head_ref }}
-
-      - name: Comment on PR if there were changes
-        if: ${{ env.CHANGES_DETECTED == 'true' && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.octo-sts.outputs.token }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "✅ Code formatting and linting was applied automatically. Please pull down the latest changes."
-            });
-
-      - name: Exit with Error If Changes Detected
-        if: env.CHANGES_DETECTED == 'true'
-        run: exit 1
 
   generate:
     if: github.ref != 'refs/heads/main' || ( github.ref == 'refs/heads/main' && github.actor != 'octo-sts[bot]')
@@ -139,22 +79,10 @@ jobs:
         go: ["1.23"]
     name: generate
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
     steps:
-      - name: Get Octo STS Token
-        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
-        id: octo-sts
-        with:
-          scope: ${{ github.repository }}
-          identity: pr-lint-format
-
       - name: Clone repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
@@ -171,61 +99,17 @@ jobs:
         run: |
           make generate
           if ! git diff --quiet; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Generated code is out of date. Changes detected."
-              echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            else
-              echo "Generated code is out of date. Run make generate and commit the changes."
-              exit 1
-            fi
+            echo "Generated code is out of date. Run make generate and commit the changes."
+            exit 1
           fi
 
       - name: Check Packages Are Up-to-Date
         run: |
           make tidy-all
           if ! git diff --quiet; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              echo "Packages are out of date. Changes detected."
-              echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-            else
-              echo "Packages are out of date. Run make tidy-all and commit the changes."
-              exit 1
-            fi
+            echo "Packages are out of date. Run make tidy-all and commit the changes."
+            exit 1
           fi
-
-      - name: Get GitHub App User ID
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/octo-sts[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-
-      - name: Commit changes
-        if: env.CHANGES_DETECTED == 'true' && github.event_name == 'pull_request'
-        run: |
-          set -eo pipefail
-          git config --global user.name 'octo-sts[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+octo-sts[bot]@users.noreply.github.com'
-          git add .
-          git commit -m "chore: Auto-update generated files"
-          git push origin HEAD:refs/heads/${{ github.head_ref }}
-
-      - name: Comment on PR if there were changes
-        if: ${{ env.CHANGES_DETECTED == 'true' && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          # github-token: ${{ steps.octo-sts.outputs.token }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "✅ Code formatting and linting was applied automatically. Please pull down the latest changes."
-            });
-
-      - name: Exit with Error If Changes Detected
-        if: env.CHANGES_DETECTED == 'true'
-        run: exit 1
 
   build:
     name: build
@@ -250,17 +134,9 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Get Octo STS Token
-        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
-        id: octo-sts
-        with:
-          scope: ${{ github.repository }}
-          identity: pr-lint-format
-
       - name: Clone repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -281,18 +157,6 @@ jobs:
           GGOARCH: ${{ matrix.GOARCH }}
         run: make build
 
-      # - name: Run GoReleaser
-      #   uses: goreleaser/goreleaser-action@v6
-      #   if: steps.cache.outputs.cache-hit != 'true'
-      #   with:
-      #     distribution: goreleaser-pro
-      #     version: latest
-      #     args: release --clean --snapshot --split
-      #   env:
-      #     GGOOS: ${{ matrix.GOOS }}
-      #     GGOARCH: ${{ matrix.GOARCH }}
-      #     GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
-      #     GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   test:
     if: github.ref != 'refs/heads/main' || ( github.ref == 'refs/heads/main' && github.actor != 'octo-sts[bot]')

--- a/.github/workflows/pr_conventional.yml
+++ b/.github/workflows/pr_conventional.yml
@@ -12,22 +12,13 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      pull-requests: read
     steps:
-      - name: Get Octo STS Token
-        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
-        id: octo-sts
-        with:
-          scope: ${{ github.repository }}
-          identity: pr-lint-format
-
       - name: Clone repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
 
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The octo token that was used to commit changes for linting, formatting, and code generation worked fine with local branches. However, when a PR was opened from a fork (i.e. from external contributions) the octo token generation failed. 

To avoid this issue, we are refactoring the pipeline to avoid committing code on feature branch pipelines. Instead, we will simply validate that lint, fmt, and generate are executed locally when necessary. 