### PR TITLE
fix(githubreceiver): nil-pointer panics on the code-scan alerts path

### DIFF
--- a/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -377,11 +378,12 @@ func TestScrape(t *testing.T) {
 	}
 }
 
-// panicResponses builds a mock-server response set for a single repo whose
-// code-scan alert has a nil Rule. That nil triggers a runtime panic deep
-// inside the per-repo scrape goroutine (via mapSeverities), exercising the
-// recover() that the scrape goroutine installs.
-func panicResponses(repoName string) *responses {
+// singleRepoResponses builds a happy-path mock-server response set for a
+// single repository. The panic-recovery tests below pair it with
+// panicRoundTripper to inject a synthetic panic from inside the per-repo
+// scrape goroutine, decoupling the recovery-path coverage from any specific
+// production nil-deref bug.
+func singleRepoResponses(repoName string) *responses {
 	return &responses{
 		scrape: true,
 		checkLoginResponse: loginResponse{
@@ -435,14 +437,28 @@ func panicResponses(repoName string) *responses {
 			depBotsAlerts: []VulnerabilityAlerts{{Nodes: []CVENode{}}},
 			responseCode:  http.StatusOK,
 		},
-		codeScanAlertResponse: codeScanAlertResponse{
-			codeScanAlerts: [][]*github.Alert{
-				// alert with nil Rule causes mapSeverities to nil-deref
-				{{Rule: nil}},
-			},
-			responseCode: http.StatusOK,
-		},
 	}
+}
+
+// panicRoundTripper wraps an inner http.RoundTripper and panics on any
+// request whose URL path contains trigger. It is the panic injector for the
+// recover()-path tests: the panic fires inside the per-repo scrape
+// goroutine's call to the GitHub client, which is exactly where the
+// production recover() must catch it.
+type panicRoundTripper struct {
+	inner   http.RoundTripper
+	trigger string
+}
+
+func (p *panicRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, p.trigger) {
+		panic("synthetic test panic from panicRoundTripper: " + req.URL.Path)
+	}
+	inner := p.inner
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return inner.RoundTrip(req)
 }
 
 // TestScrapeRecoversFromPanic asserts that a runtime panic inside a per-repo
@@ -454,16 +470,15 @@ func TestScrapeRecoversFromPanic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	server := httptest.NewServer(MockServer(panicResponses("repo1")))
+	server := httptest.NewServer(MockServer(singleRepoResponses("repo1")))
 	defer server.Close()
 
 	cfg := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
 	cfg.Metrics.VcsCveCount.Enabled = true
 
 	// Attach an observed logger so the test can confirm a panic was actually
-	// recovered. Without this guard, hardening the underlying nil-deref in
-	// mapSeverities would silently turn this test into a happy-path no-op
-	// that still passes.
+	// recovered. Without this guard, removing the panic injector below would
+	// silently turn this test into a happy-path no-op that still passes.
 	core, recorded := observer.New(zap.ErrorLevel)
 	settings := receivertest.NewNopSettings(metadata.Type)
 	settings.Logger = zap.New(core)
@@ -474,6 +489,15 @@ func TestScrapeRecoversFromPanic(t *testing.T) {
 	ghs.cfg.ConcurrencyLimit = 1000
 
 	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	// Inject a synthetic panic from inside the per-repo scrape goroutine by
+	// wrapping the HTTP transport. The code-scanning REST call is the last
+	// per-repo HTTP request and runs after mux.Lock(), so the panic exercises
+	// both recover() and defer mux.Unlock() in github_scraper.go.
+	ghs.client.Transport = &panicRoundTripper{
+		inner:   ghs.client.Transport,
+		trigger: "/code-scanning/alerts",
+	}
 
 	metrics, err := ghs.scrape(ctx)
 	require.NoError(t, err)
@@ -495,9 +519,10 @@ func TestScrapeLogsRecoveredPanic(t *testing.T) {
 	defer cancel()
 
 	// The mock server hard-codes "/api/v3/repos/liatrio/repo1/..." for the
-	// REST endpoints, so the failing repo must be "repo1" for the code-scan
-	// path to hit our handler.
-	server := httptest.NewServer(MockServer(panicResponses("repo1")))
+	// REST endpoints, so the failing repo must be "repo1" so all per-repo
+	// HTTP calls are served (and so panicRoundTripper has a code-scanning
+	// request to match against).
+	server := httptest.NewServer(MockServer(singleRepoResponses("repo1")))
 	defer server.Close()
 
 	cfg := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
@@ -513,6 +538,11 @@ func TestScrapeLogsRecoveredPanic(t *testing.T) {
 	ghs.cfg.ConcurrencyLimit = 1000
 
 	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	ghs.client.Transport = &panicRoundTripper{
+		inner:   ghs.client.Transport,
+		trigger: "/code-scanning/alerts",
+	}
 
 	_, err := ghs.scrape(ctx)
 	require.NoError(t, err)
@@ -535,11 +565,11 @@ func TestScrapeDoesNotDeadlockAfterRecoveredPanic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Two repos: repo1's code-scan alert has a nil Rule and panics inside
-	// the goroutine after mux.Lock(). repo2's REST endpoints are not
-	// registered by the mock (only /repos/liatrio/repo1/... is), so its
-	// calls 404 cleanly and the goroutine reaches its own mux.Lock().
-	r := panicResponses("repo1")
+	// Two repos under ConcurrencyLimit=1 so they run sequentially. Both
+	// goroutines panic on their code-scanning HTTP call (see the
+	// panicRoundTripper installed below); the assertion is that repo2's
+	// mux.Lock() does not block on a lock leaked from repo1's panic.
+	r := singleRepoResponses("repo1")
 	r.searchRepoResponse.repos = []getRepoDataBySearchSearchSearchResultItemConnection{
 		{
 			RepositoryCount: 2,
@@ -595,6 +625,11 @@ func TestScrapeDoesNotDeadlockAfterRecoveredPanic(t *testing.T) {
 	ghs.cfg.ConcurrencyLimit = 1
 
 	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	ghs.client.Transport = &panicRoundTripper{
+		inner:   ghs.client.Transport,
+		trigger: "/code-scanning/alerts",
+	}
 
 	done := make(chan struct{})
 	var scrapeErr error

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
@@ -463,7 +463,7 @@ func (ghs *githubScraper) getCodeScanAlerts(
 	for {
 		a, resp, err := rClient.CodeScanning.ListAlertsForRepo(ctx, ghs.cfg.GitHubOrg, repo, opt)
 		if err != nil {
-			if resp.StatusCode == 404 || resp.StatusCode == 403 {
+			if resp != nil && (resp.StatusCode == 404 || resp.StatusCode == 403) {
 				ghs.logger.Sugar().Debugf("%s repo does not have any alerts or does not have alerts enabled", repo)
 				break
 			}

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
@@ -505,6 +505,9 @@ func mapSeverities(
 	}
 
 	for _, alert := range alerts {
+		if alert.Rule == nil || alert.Rule.SecuritySeverityLevel == nil {
+			continue
+		}
 		if val, found := mapping[strings.ToUpper(*alert.Rule.SecuritySeverityLevel)]; found {
 			m[val]++
 		}

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -1630,6 +1630,45 @@ func TestGetCVEs(t *testing.T) {
 	}
 }
 
+// Covers the 404/403 break path in getCodeScanAlerts, which previously
+// short-circuited without a nil check on resp. With the nil-guard added,
+// the response is non-nil and carries a real status, so we expect the
+// scraper to swallow the error and return nil alerts (not an error).
+func TestGetCodeScanAlertsRepoWithoutAlerts(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		statusCode int
+	}{
+		{desc: "404 not found", statusCode: http.StatusNotFound},
+		{desc: "403 forbidden", statusCode: http.StatusForbidden},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			factory := Factory{}
+			defaultConfig := factory.CreateDefaultConfig()
+			settings := receivertest.NewNopSettings(metadata.Type)
+			ghs := newGitHubScraper(settings, defaultConfig.(*Config))
+			ghs.cfg.GitHubOrg = "o"
+
+			rClient := github.NewClient(nil)
+			u, err := url.Parse(server.URL + "/api-v3" + "/")
+			assert.NoError(t, err)
+			rClient.BaseURL = u
+			rClient.UploadURL = u
+
+			assert.NotPanics(t, func() {
+				alerts := ghs.getCodeScanAlerts(context.Background(), rClient, "r")
+				assert.Nil(t, alerts)
+			})
+		})
+	}
+}
+
 // Regression test for nil-pointer panic when go-github returns (nil, nil, err)
 // from ListAlertsForRepo — e.g. when the context is cancelled before the HTTP
 // response is received. Previously, getCodeScanAlerts read resp.StatusCode

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -1629,3 +1629,25 @@ func TestGetCVEs(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for nil-pointer panic when go-github returns (nil, nil, err)
+// from ListAlertsForRepo — e.g. when the context is cancelled before the HTTP
+// response is received. Previously, getCodeScanAlerts read resp.StatusCode
+// without a nil check and crashed the entire collector pod.
+func TestGetCodeScanAlertsNilResponse(t *testing.T) {
+	factory := Factory{}
+	defaultConfig := factory.CreateDefaultConfig()
+	settings := receivertest.NewNopSettings(metadata.Type)
+	ghs := newGitHubScraper(settings, defaultConfig.(*Config))
+	ghs.cfg.GitHubOrg = "o"
+
+	rClient := github.NewClient(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.NotPanics(t, func() {
+		alerts := ghs.getCodeScanAlerts(ctx, rClient, "r")
+		assert.Nil(t, alerts)
+	})
+}

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -1651,3 +1651,49 @@ func TestGetCodeScanAlertsNilResponse(t *testing.T) {
 		assert.Nil(t, alerts)
 	})
 }
+
+// Regression tests for nil-pointer panics in mapSeverities. GitHub's REST API
+// has been observed to omit Rule or its SecuritySeverityLevel on some alert
+// states; before the guard, the bare *alert.Rule.SecuritySeverityLevel
+// dereference crashed the entire collector pod. The mixed case also guards
+// against the nil-skip becoming an over-skip that drops well-formed alerts.
+func TestMapSeveritiesCodeScanAlerts(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		alerts   []*github.Alert
+		expected map[metadata.AttributeCveSeverity]int64
+	}{
+		{
+			desc:     "nil Rule is skipped",
+			alerts:   []*github.Alert{{Rule: nil}},
+			expected: map[metadata.AttributeCveSeverity]int64{},
+		},
+		{
+			desc:     "nil SecuritySeverityLevel is skipped",
+			alerts:   []*github.Alert{{Rule: &github.Rule{SecuritySeverityLevel: nil}}},
+			expected: map[metadata.AttributeCveSeverity]int64{},
+		},
+		{
+			desc: "valid alerts are counted alongside malformed ones",
+			alerts: []*github.Alert{
+				{Rule: nil},
+				{Rule: &github.Rule{SecuritySeverityLevel: nil}},
+				{Rule: &github.Rule{SecuritySeverityLevel: github.Ptr("HIGH")}},
+				{Rule: &github.Rule{SecuritySeverityLevel: github.Ptr("CRITICAL")}},
+			},
+			expected: map[metadata.AttributeCveSeverity]int64{
+				metadata.AttributeCveSeverityHigh:     1,
+				metadata.AttributeCveSeverityCritical: 1,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			var got map[metadata.AttributeCveSeverity]int64
+			assert.NotPanics(t, func() {
+				got = mapSeverities(nil, tc.alerts)
+			})
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two independent nil-deref panics on the code-scan alerts code path could each crash the entire collector pod and drop the scrape's metrics. Both are fixed here.

Fixes #799.

## Changes

- **`getCodeScanAlerts` — nil HTTP response** (`helpers.go`). The function read `resp.StatusCode` without checking `resp != nil`, panicking whenever `go-github` returned `(nil, nil, err)` (context cancel, DNS failure, TLS handshake failure, connection reset). Added a one-line nil guard on `resp`. Regression test `TestGetCodeScanAlertsNilResponse` reproduces the original panic by passing a pre-cancelled context.
- **`mapSeverities` — nil `Rule` / nil `SecuritySeverityLevel`** (`helpers.go`). GitHub's REST API can return code-scan alerts where `Rule` is unset, or where `Rule.SecuritySeverityLevel` is nil independently of the rule. The bare `*alert.Rule.SecuritySeverityLevel` dereference panicked on either. Skip such alerts and continue counting well-formed ones. Table-driven test `TestMapSeveritiesCodeScanAlerts` covers nil `Rule`, nil `SecuritySeverityLevel`, and a mixed batch (regression-safety against the guard becoming an over-skip that drops well-formed alerts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when GitHub code-scanning endpoints fail, return error statuses, or yield incomplete/missing alert data.

* **Tests**
  * Added regression tests to ensure safe handling of failed API responses, cancelled requests, and alerts missing rule or severity information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liatrio/liatrio-otel-collector/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->