### PR TITLE
fix(githubreceiver): recover from panics in per-repo scrape goroutines

### DIFF
--- a/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper.go
@@ -130,6 +130,16 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				<-limiter
 				wg.Done()
 			}()
+			defer func() {
+				if r := recover(); r != nil {
+					ghs.logger.Error(
+						"recovered from panic in per-repo scrape goroutine",
+						zap.String("repo", name),
+						zap.Any("panic", r),
+						zap.Stack("stacktrace"),
+					)
+				}
+			}()
 
 			branches, count, err := ghs.getBranches(ctx, genClient, name, trunk)
 			if err != nil {
@@ -137,8 +147,12 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			}
 
 			// Create a mutual exclusion lock to prevent the recordDataPoint
-			// SetStartTimestamp call from having a nil pointer panic
+			// SetStartTimestamp call from having a nil pointer panic. The
+			// unlock is deferred so a panic in any of the helper calls below
+			// (caught by the recover() above) does not leak the lock and
+			// deadlock sibling per-repo goroutines.
 			mux.Lock()
+			defer mux.Unlock()
 
 			refType := metadata.AttributeVcsRefHeadTypeBranch
 			ghs.mb.RecordVcsRefCountDataPoint(now, int64(count), url, name, refType)
@@ -232,7 +246,6 @@ func (ghs *githubScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 			ghs.mb.RecordVcsChangeCountDataPoint(now, int64(open), url, metadata.AttributeVcsChangeStateOpen, name)
 			ghs.mb.RecordVcsChangeCountDataPoint(now, int64(merged), url, metadata.AttributeVcsChangeStateMerged, name)
-			mux.Unlock()
 		}()
 	}
 

--- a/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
@@ -597,8 +597,9 @@ func TestScrapeDoesNotDeadlockAfterRecoveredPanic(t *testing.T) {
 	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
 
 	done := make(chan struct{})
+	var scrapeErr error
 	go func() {
-		_, _ = ghs.scrape(ctx)
+		_, scrapeErr = ghs.scrape(ctx)
 		close(done)
 	}()
 
@@ -607,6 +608,7 @@ func TestScrapeDoesNotDeadlockAfterRecoveredPanic(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("scrape deadlocked: recovered panic left the per-repo mutex locked")
 	}
+	require.NoError(t, scrapeErr)
 
 	require.NotEmpty(t, recorded.FilterMessageSnippet("panic").All(),
 		"test no longer triggers a panic — deferred-unlock path is not being exercised")

--- a/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/github_scraper_test.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewGitHubScraper(t *testing.T) {
@@ -373,4 +375,239 @@ func TestScrape(t *testing.T) {
 			}
 		})
 	}
+}
+
+// panicResponses builds a mock-server response set for a single repo whose
+// code-scan alert has a nil Rule. That nil triggers a runtime panic deep
+// inside the per-repo scrape goroutine (via mapSeverities), exercising the
+// recover() that the scrape goroutine installs.
+func panicResponses(repoName string) *responses {
+	return &responses{
+		scrape: true,
+		checkLoginResponse: loginResponse{
+			checkLogin: checkLoginResponse{
+				Organization: checkLoginOrganization{Login: "liatrio"},
+			},
+			responseCode: http.StatusOK,
+		},
+		searchRepoResponse: searchRepoResponse{
+			repos: []getRepoDataBySearchSearchSearchResultItemConnection{
+				{
+					RepositoryCount: 1,
+					Nodes: []SearchNode{
+						&SearchNodeRepository{Repo: Repo{Name: repoName}},
+					},
+					PageInfo: getRepoDataBySearchSearchSearchResultItemConnectionPageInfo{
+						HasNextPage: false,
+					},
+				},
+			},
+			responseCode: http.StatusOK,
+		},
+		branchResponse: branchResponse{
+			branches: []getBranchDataRepositoryRefsRefConnection{
+				{
+					TotalCount: 0,
+					Nodes:      []BranchNode{},
+					PageInfo: getBranchDataRepositoryRefsRefConnectionPageInfo{
+						HasNextPage: false,
+					},
+				},
+			},
+			responseCode: http.StatusOK,
+		},
+		prResponse: prResponse{
+			prs: []getPullRequestDataRepositoryPullRequestsPullRequestConnection{
+				{
+					PageInfo: getPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+						HasNextPage: false,
+					},
+					Nodes: []PullRequestNode{},
+				},
+			},
+			responseCode: http.StatusOK,
+		},
+		contribResponse: contribResponse{
+			contribs:     [][]*github.Contributor{{}},
+			responseCode: http.StatusOK,
+		},
+		depBotAlertResponse: depBotAlertResponse{
+			depBotsAlerts: []VulnerabilityAlerts{{Nodes: []CVENode{}}},
+			responseCode:  http.StatusOK,
+		},
+		codeScanAlertResponse: codeScanAlertResponse{
+			codeScanAlerts: [][]*github.Alert{
+				// alert with nil Rule causes mapSeverities to nil-deref
+				{{Rule: nil}},
+			},
+			responseCode: http.StatusOK,
+		},
+	}
+}
+
+// TestScrapeRecoversFromPanic asserts that a runtime panic inside a per-repo
+// scrape goroutine does not bring down the collector: scrape returns to its
+// caller and metrics recorded prior to the failing goroutine are still emitted.
+// Without recover() in place the panic propagates out of the goroutine and
+// crashes the test binary.
+func TestScrapeRecoversFromPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	server := httptest.NewServer(MockServer(panicResponses("repo1")))
+	defer server.Close()
+
+	cfg := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
+	cfg.Metrics.VcsCveCount.Enabled = true
+
+	// Attach an observed logger so the test can confirm a panic was actually
+	// recovered. Without this guard, hardening the underlying nil-deref in
+	// mapSeverities would silently turn this test into a happy-path no-op
+	// that still passes.
+	core, recorded := observer.New(zap.ErrorLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(core)
+
+	ghs := newGitHubScraper(settings, cfg)
+	ghs.cfg.GitHubOrg = "liatrio"
+	ghs.cfg.ClientConfig.Endpoint = server.URL
+	ghs.cfg.ConcurrencyLimit = 1000
+
+	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	metrics, err := ghs.scrape(ctx)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, recorded.FilterMessageSnippet("panic").All(),
+		"test no longer triggers a panic — recovery path is not being exercised")
+
+	// The repository count metric is recorded before the goroutine fan-out,
+	// so it must still be present after a panic is recovered.
+	require.Equal(t, 1, metrics.ResourceMetrics().Len())
+}
+
+// TestScrapeLogsRecoveredPanic asserts that a panic in a per-repo scrape
+// goroutine is logged as an error with the repo name and the recovered value
+// so operators can identify which repo failed without re-deriving it from a
+// stack trace.
+func TestScrapeLogsRecoveredPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// The mock server hard-codes "/api/v3/repos/liatrio/repo1/..." for the
+	// REST endpoints, so the failing repo must be "repo1" for the code-scan
+	// path to hit our handler.
+	server := httptest.NewServer(MockServer(panicResponses("repo1")))
+	defer server.Close()
+
+	cfg := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
+	cfg.Metrics.VcsCveCount.Enabled = true
+
+	core, recorded := observer.New(zap.ErrorLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(core)
+
+	ghs := newGitHubScraper(settings, cfg)
+	ghs.cfg.GitHubOrg = "liatrio"
+	ghs.cfg.ClientConfig.Endpoint = server.URL
+	ghs.cfg.ConcurrencyLimit = 1000
+
+	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	_, err := ghs.scrape(ctx)
+	require.NoError(t, err)
+
+	entries := recorded.FilterMessageSnippet("panic").All()
+	require.Len(t, entries, 1, "expected exactly one recovery log entry")
+
+	fields := entries[0].ContextMap()
+	require.Equal(t, "repo1", fields["repo"], "log must identify the failing repo")
+	require.NotNil(t, fields["panic"], "log must carry the recovered value")
+}
+
+// TestScrapeDoesNotDeadlockAfterRecoveredPanic asserts that the per-repo
+// mutex is released when a goroutine panics. The original code took the lock
+// with mux.Lock() and released it manually near the end of the function, so a
+// panic between those points (now caught by recover()) leaves the mutex held
+// and any sibling goroutine deadlocks on its own mux.Lock(), which then hangs
+// wg.Wait() and the entire scrape call. The fix is to defer mux.Unlock().
+func TestScrapeDoesNotDeadlockAfterRecoveredPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Two repos: repo1's code-scan alert has a nil Rule and panics inside
+	// the goroutine after mux.Lock(). repo2's REST endpoints are not
+	// registered by the mock (only /repos/liatrio/repo1/... is), so its
+	// calls 404 cleanly and the goroutine reaches its own mux.Lock().
+	r := panicResponses("repo1")
+	r.searchRepoResponse.repos = []getRepoDataBySearchSearchSearchResultItemConnection{
+		{
+			RepositoryCount: 2,
+			Nodes: []SearchNode{
+				&SearchNodeRepository{Repo: Repo{Name: "repo1"}},
+				&SearchNodeRepository{Repo: Repo{Name: "repo2"}},
+			},
+			PageInfo: getRepoDataBySearchSearchSearchResultItemConnectionPageInfo{
+				HasNextPage: false,
+			},
+		},
+	}
+	// Per-repo GraphQL responses are indexed by a page counter that
+	// advances on every request, so we need one entry per repo.
+	emptyBranches := getBranchDataRepositoryRefsRefConnection{
+		TotalCount: 0,
+		Nodes:      []BranchNode{},
+		PageInfo: getBranchDataRepositoryRefsRefConnectionPageInfo{
+			HasNextPage: false,
+		},
+	}
+	r.branchResponse.branches = []getBranchDataRepositoryRefsRefConnection{emptyBranches, emptyBranches}
+	emptyPRs := getPullRequestDataRepositoryPullRequestsPullRequestConnection{
+		PageInfo: getPullRequestDataRepositoryPullRequestsPullRequestConnectionPageInfo{
+			HasNextPage: false,
+		},
+		Nodes: []PullRequestNode{},
+	}
+	r.prResponse.prs = []getPullRequestDataRepositoryPullRequestsPullRequestConnection{emptyPRs, emptyPRs}
+	r.depBotAlertResponse.depBotsAlerts = []VulnerabilityAlerts{
+		{Nodes: []CVENode{}},
+		{Nodes: []CVENode{}},
+	}
+
+	server := httptest.NewServer(MockServer(r))
+	defer server.Close()
+
+	cfg := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
+	cfg.Metrics.VcsCveCount.Enabled = true
+
+	// Same guard as TestScrapeRecoversFromPanic: if the underlying panic
+	// trigger ever stops firing, the deadlock scenario no longer exists and
+	// this test would silently pass without exercising the deferred unlock.
+	core, recorded := observer.New(zap.ErrorLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(core)
+
+	ghs := newGitHubScraper(settings, cfg)
+	ghs.cfg.GitHubOrg = "liatrio"
+	ghs.cfg.ClientConfig.Endpoint = server.URL
+	// Force sequential execution so the second goroutine only starts after
+	// the first has panicked-and-recovered, removing any timing ambiguity.
+	ghs.cfg.ConcurrencyLimit = 1
+
+	require.NoError(t, ghs.start(ctx, componenttest.NewNopHost()))
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = ghs.scrape(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scrape deadlocked: recovered panic left the per-repo mutex locked")
+	}
+
+	require.NotEmpty(t, recorded.FilterMessageSnippet("panic").All(),
+		"test no longer triggers a panic — deferred-unlock path is not being exercised")
 }


### PR DESCRIPTION
## Summary

Closes #801.

A panic anywhere in the per-repo scrape goroutine (e.g. the nil-deref behind #799/#800) brings down the entire collector pod and drops every metric for that scrape — `mb.Emit()` only runs after `wg.Wait()` returns in the parent goroutine. Per-repo failures should be loggable, not fatal.

This PR wraps the goroutine body in `defer recover()` and switches the per-repo mutex to `defer mux.Unlock()` so a recovered panic does not leak the lock and deadlock sibling goroutines.

## Changes

- **`github_scraper.go`**
  - Add `defer recover()` to the per-repo goroutine; log the failure with the repo name, the recovered value, and a `zap.Stack` stack trace via the structured `zap.Logger` API.
  - Replace the manual `mux.Unlock()` at the bottom of the goroutine with `defer mux.Unlock()` immediately after `mux.Lock()`. Without this, a recovered panic would hold the lock forever and hang `wg.Wait()`.
- **`github_scraper_test.go`** — three new tests, all using a `zaptest/observer` core to assert a panic was actually recovered (so future hardening of the underlying trigger fails the test loudly instead of silently turning it into a happy-path no-op):
  - `TestScrapeRecoversFromPanic` — scrape returns cleanly and pre-fan-out metrics still emit.
  - `TestScrapeLogsRecoveredPanic` — recovery is logged with `repo` and `panic` fields.
  - `TestScrapeDoesNotDeadlockAfterRecoveredPanic` — two repos under `ConcurrencyLimit = 1`; the second goroutine completes within 5s, proving the mutex was released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scraper resilience by adding panic recovery during per-repository processing so operations continue gracefully if a worker panics.
  * Prevented potential deadlocks in concurrent repository processing by ensuring locks are reliably released even on panic.

* **Tests**
  * Added tests validating panic recovery, that recovered panics are logged once with context, and that no deadlock occurs after recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liatrio/liatrio-otel-collector/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->