### PR TITLE
fix(ci): drop stale head_ref override that breaks fork PR checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -84,7 +83,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

The \`lint\` and \`generate\` jobs in \`.github/workflows/build.yml\` override \`actions/checkout\`'s \`ref:\` with \`\${{ github.head_ref }}\`. For fork PRs, that's the branch name on the fork (e.g. \`fix/code-scan-alerts-nil-deref\` on \`nissessenap/liatrio-otel-collector\`), but \`actions/checkout\` defaults \`repository:\` to the base repo. Checkout asks the base repo for a branch that only exists on the fork and fails:

\`\`\`
##[error]A branch or tag with the name 'fix/code-scan-alerts-nil-deref' could not be found
\`\`\`

This blocks every fork PR at the \`lint\` and \`generate\` steps. \`build\` and \`test\` pass because they don't override \`ref:\` — they use the default \`pull_request\` merge ref, which GitHub creates in the base repo.

Currently visible on #800 and #802.

## Why the override was there

Added in #704 alongside an auto-commit-back workflow that ran \`make generate\` / \`make tidy-all\` and pushed the results to the PR branch via \`git push origin HEAD:refs/heads/\${{ github.head_ref }}\`. That use case required checking out the actual branch by name (you can't push to a merge ref). It worked for same-repo PRs and was always broken for fork PRs.

#761 ripped out the octo-sts token step, the \`git push\`, the PR comment, and the \`CHANGES_DETECTED\` plumbing — but left both \`ref:\` lines in the checkout config. With nothing pushing back, the override is vestigial. Fork PRs are the first traffic to surface it since that cleanup landed 2025-09-29.

## Changes

Drop the \`ref: \${{ github.head_ref }}\` line from the \`lint\` and \`generate\` checkout steps so both jobs use the default merge ref, matching \`build\` and \`test\`.

## Test plan

- [ ] Open a fork PR (or rebase #800 / #802 on this branch) and confirm \`lint (1.24)\` and \`generate (1.24)\` get past the checkout step and run their actual steps
- [ ] Same-repo PR continues to lint and generate normally
- [ ] Push to \`main\` still runs lint/generate against the merge ref as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified GitHub Actions workflow configuration for build and linting processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liatrio/liatrio-otel-collector/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->