### PR TITLE
fix(ci): wire CODECOV_TOKEN into the upload step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   multimod-prepare-release:
     if: ${{ github.ref == 'refs/heads/main' && github.actor != 'octo-sts[bot]' }}


### PR DESCRIPTION
## Summary

\`codecov-action\` v4 (merged via Renovate as a01553d on 2024-02-01, 55 seconds after the last upload codecov has on file) made the token required for public-repo uploads. The workflow has never passed one, so every main upload since has been silently dropped — codecov's stored baseline has been pinned at \`9404fca\` for **two years**, and every PR's \`codecov/project\` check has been comparing against a Feb 2024 snapshot.

The trial that previously masked this just expired, so the failure mode is now visible (#800 and #802 currently fail \`codecov/project\` for this reason).

## Changes

- Pass \`secrets.CODECOV_TOKEN\` to the \`codecov-action\` step in the \`test\` job so authenticated uploads start landing again.
- Set \`fail_ci_if_error: true\` so the next breakage surfaces as a failed check instead of silently rotting the baseline again.

\`CODECOV_TOKEN\` has been provisioned as a repo secret separately.

## Test plan

- [ ] PR's own \`test (1.24)\` step shows a non-zero \`Token length\` in the codecov upload log
- [ ] After merge, the first main run successfully ingests; codecov dashboard shows a recent commit as the new baseline
- [ ] Re-run CI on #800 and #802; \`codecov/project\` should compare against a current baseline and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration for improved code coverage upload reliability and authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liatrio/liatrio-otel-collector/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->