### PR TITLE
ci: add advanced CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+---
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        if: matrix.language == 'go'
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,16 +34,16 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
         if: matrix.language == 'go'
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Default CodeQL setup analyzes same-repo branches but skips fork PRs by design, leaving any \`CodeQL\` branch protection requirement permanently unsatisfied on fork PRs. This is what blocked #800 and #802 from merging earlier today — the required check could never report.

Switching to advanced setup with a custom workflow lets CodeQL run on fork PRs too, while keeping the same security posture.

## ⚠️ Rollout — do this BEFORE clicking merge

This PR alone does not switch CodeQL over; default setup blocks any advanced workflow's results from being accepted by the code-scanning API. As of writing, this PR's own \`Analyze (go)\` and \`Analyze (actions)\` checks are red with:

\`\`\`
##[error]Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
\`\`\`

That failure is **expected** and is the proof that default setup must go first. The order matters:

1. **Disable default CodeQL setup** — Settings → Code security and analysis → \"Default setup\" → Disable. The existing default-setup \`Analyze (go)\` / \`Analyze (actions)\` checks stop reporting on new PRs.
2. **Re-run this PR's CI.** The advanced workflow's SARIF upload will now be accepted; the failing \`Analyze (*)\` checks turn green.
3. **Merge this PR.** The new \`codeql.yml\` is now the active CodeQL config, and \`Analyze (go)\` / \`Analyze (actions)\` checks report on every PR — same-repo and fork.
4. **Update branch protection** on \`main\`: remove the legacy \`CodeQL\` required check (the deadlocking one), add \`Analyze (go)\` and \`Analyze (actions)\` instead. The new checks are produced by the workflow in this PR.

There's a brief window between step 1 and step 3 where no CodeQL runs on PRs — usually a few minutes. Don't do this during a code-freeze window where a CodeQL gate matters.

## Security note

Running CodeQL on fork PRs would be dangerous if the workflow used \`pull_request_target\` — that event runs with the base branch's permissions and secrets, and combined with checking out the PR's code is the [classic \"pwn request\" pattern](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

This workflow uses **\`pull_request\`**, not \`pull_request_target\`. On a fork PR:
- The \`GITHUB_TOKEN\` is read-only regardless of the declared \`permissions:\` block (per GitHub Docs)
- The \`secrets:\` context is empty
- Autobuild runs the PR's \`go build\` — but Go doesn't execute arbitrary code at build time (no \`postinstall\`-equivalent), so the build-time RCE surface that makes this nuanced for npm/Python isn't a concern
- All third-party actions are pinned by immutable commit SHA, so a retag-based supply-chain attack against \`github/codeql-action\` cannot affect us

Worst case from a hostile fork PR is wasted CI minutes (free on public repos) and CodeQL surfacing findings — which is the point.

## Fork PR approval gating

This workflow obeys the existing Actions setting for outside contributors: when an external contributor opens a fork PR, all workflows (this one included) go to \`action_required\` and need a maintainer click to run. Same UX as the existing \`build-and-test\` workflow today.

## Config choices

- **Triggers**: push to main, PRs to main, weekly schedule (Mondays 06:23 UTC — picks up CodeQL query pack updates; jittered minute to avoid the round-number cron queue)
- **Languages**: \`go\` and \`actions\` — the \`actions\` analyzer lints workflow YAML for injection patterns and would have caught the \`github.head_ref\` bug shipped in #761
- **Queries**: \`security-and-quality\` instead of just \`security\` — broader, surfaces correctness and style findings
- **Concurrency**: cancel in-progress runs on the same ref
- **\`ubuntu-latest\`** runners only, public-repo free tier — no cost impact
- **All actions SHA-pinned** to match the existing repo convention (\`actions/checkout\`, \`github/codeql-action/{init,autobuild,analyze}\`)

## Test plan

- [ ] After step 1 (disable default setup) + step 2 (re-run), this PR's \`Analyze (go)\` and \`Analyze (actions)\` go green
- [ ] After merging + step 4 (branch protection update), a fork PR (e.g., re-trigger #800 / #802) gets real \`Analyze (go)\` / \`Analyze (actions)\` checks instead of a deadlocked CodeQL gate
- [ ] Same-repo PR continues to work as before
- [ ] First scheduled run (Mon 06:23 UTC) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)