### PR TITLE
fix(codeql): use manual build mode for multi-module Go layout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,7 @@ jobs:
             -not -path './.claude/*' \
             -not -path './.tools/*' \
             -not -path './vendor/*' \
+            -not -path './go.mod' \
             -exec dirname {} \;)
           for dir in "${modules[@]}"; do
             echo "::group::go build $dir"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [go, actions]
+        include:
+          - language: go
+            build-mode: none
+          - language: actions
+            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,11 +41,8 @@ jobs:
         uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
-
-      - name: Autobuild
-        if: matrix.language == 'go'
-        uses: github/codeql-action/autobuild@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
 
       - name: Analyze
         uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - language: go
-            build-mode: none
+            build-mode: manual
           - language: actions
             build-mode: none
     steps:
@@ -43,6 +43,31 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
+
+      # Multi-module layout: a stub root go.mod plus one go.mod per
+      # subdirectory and no go.work, so Autobuild's "go build ./..." at
+      # the root finds nothing. Walk each module's go.mod and build it
+      # under CodeQL's tracer so every package gets extracted.
+      #
+      # CodeQL bundles its own Go SDK and prepends it to PATH, so no
+      # actions/setup-go step is needed. Autobuild handles `go mod
+      # download` automatically; manual mode has to do it explicitly.
+      - name: Manual build (Go)
+        if: matrix.language == 'go'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t modules < <(find . -name go.mod \
+            -not -path './.git/*' \
+            -not -path './.claude/*' \
+            -not -path './.tools/*' \
+            -not -path './vendor/*' \
+            -exec dirname {} \;)
+          for dir in "${modules[@]}"; do
+            echo "::group::go build $dir"
+            (cd "$dir" && go mod download && go build ./...)
+            echo "::endgroup::"
+          done
 
       - name: Analyze
         uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5


### PR DESCRIPTION
## Summary

\`Analyze (go)\` has been reporting green on \`main\` without actually analyzing anything. Every run logs:

\`\`\`
##[group]Go files were found but not processed (1 result)
\`\`\`

## Root cause

Multi-module Go layout:

- Root \`go.mod\` is a stub (\`module github.com/liatrio/liatrio-otel-collector\`, no source in its own scope)
- Eight real modules live in subdirectories (\`extension/\`, \`processor/\`, \`receiver/*\`, \`cmd/\`, \`internal/\`)
- No root \`go.work\` ties them together

CodeQL's \`Autobuild\` for Go boils down to \"\`go build ./...\` at the repo root.\" Under a stub root module, \`./...\` resolves to zero packages. Autobuild reports success having extracted nothing, the database is empty, and Analyze reports zero results — green, but no Go was actually analyzed.

## Fix

Switch Go to **\`build-mode: manual\`** and walk each \`go.mod\` directory under CodeQL's tracer.

\`build-mode: none\` is **not** an option for Go (initial attempt confirmed via CodeQL's own error: *\"Go does not support the none build mode. Please try using one of the following build modes instead: autobuild, manual.\"*). Per current docs (\`codeql-build-options-and-steps-for-compiled-languages.md\`): *\"CodeQL supports both autobuild and manual build modes for Go code.\"* Go's extractor needs to observe \`compile\` invocations to extract type info.

Workflow changes:
- Matrix uses \`include:\` so each row carries both \`language\` and \`build-mode\` (cleaner than a conditional)
- \`Initialize CodeQL\` step gets \`build-mode\` passed through
- New \`Manual build (Go)\` step: finds every \`go.mod\` (excluding root stub, \`.git\`, \`.claude\` agent worktrees, \`.tools\`, \`vendor\`) and runs \`go mod download && go build ./...\` in each module under CodeQL's tracer
- Old \`Autobuild\` step removed
- The \`actions\` analyzer keeps \`build-mode: none\` — that's the only valid value for the workflow-YAML analyzer

Notes:
- **No \`actions/setup-go\`** is needed — \`codeql-action/init\` ships its own Go SDK and prepends it to PATH (per \`preparing-your-code-for-codeql-analysis.md\`)
- **\`go mod download\` is explicit** in manual mode; Autobuild does this automatically, manual must replicate it or modules with un-cached deps fail to build
- **Root \`go.mod\` is excluded** by an explicit \`-not -path './go.mod'\` filter — including it caused a harmless \`'./...' matched no packages\` warning and a cosmetic \`'Go files were found but not processed'\` CodeQL diagnostic; both eliminated

## Alternatives considered

- **Add a root \`go.work\`** listing all 8 modules. Works for CodeQL, but changes how local tooling and \`make for-all\` iteration see the workspace. Risk of subtle breakage outside CI for a fix that should be CI-only.
- **Use \`build-mode: none\` (initial attempt).** Confirmed unsupported for Go by CodeQL.

## Test plan

- [x] CI run on this branch shows \`Analyze (go)\` succeeding and 8 module \`go build\` invocations under the tracer
- [x] Stub-root \`go.mod\` diagnostic no longer present in the latest run
- [ ] \`Analyze (actions)\` still passes
- [ ] After merge, post-merge main run produces real findings in the Security tab → Code scanning view
- [ ] First scheduled run (Mon 06:23 UTC) succeeds with non-empty Go analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)