### PR TITLE
fix(codeql): also compile test files so they're extracted

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,14 @@ jobs:
       # the root finds nothing. Walk each module's go.mod and build it
       # under CodeQL's tracer so every package gets extracted.
       #
+      # `go build ./...` compiles production code only — *_test.go files
+      # are skipped, leaving ~46% of this repo's Go source unscanned.
+      # `go test -count=1 -run='^$' ./...` compiles every test binary
+      # (tracer captures the compiles) but the empty-regex `-run`
+      # filter executes no test bodies. `-count=1` disables the test
+      # cache so compilation always happens. This mirrors upstream
+      # codeql-action autobuild's two-pass behavior.
+      #
       # CodeQL bundles its own Go SDK and prepends it to PATH, so no
       # actions/setup-go step is needed. Autobuild handles `go mod
       # download` automatically; manual mode has to do it explicitly.
@@ -65,8 +73,11 @@ jobs:
             -not -path './go.mod' \
             -exec dirname {} \;)
           for dir in "${modules[@]}"; do
-            echo "::group::go build $dir"
-            (cd "$dir" && go mod download && go build ./...)
+            echo "::group::go build + test compile $dir"
+            (cd "$dir" && \
+              go mod download && \
+              go build ./... && \
+              go test -count=1 -run='^$' ./...)
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## Summary

After #807 fixed the multi-module Autobuild gap, the security tab still reports Go at **77/143 files scanned (54%)**. The unscanned half is the test files: \`go build ./...\` compiles production packages only — \`*_test.go\` files are never handed to CodeQL's extractor.

\`\`\`
$ find . -name '*.go' | wc -l           # 143
$ find . -name '*_test.go' | wc -l      #  65
$ find . -name '*.go' -not -name '*_test.go' | wc -l  # 78
\`\`\`

77 ≈ 78 production files. The 65 test files are the gap.

## Why this matters

Test files in this repo exercise auth flows (\`extension/githubappauthextension\`), HTTP scraping with various GitHub/GitLab/Azure DevOps response shapes, credential handling helpers, and mock setups — exactly the kind of code where CodeQL surfaces taint flows, hardcoded secrets, and crypto misuse. Leaving them unscanned defeats half the point of running \`security-and-quality\`.

## Fix

Add a test-compilation pass to the existing module loop:

\`\`\`bash
(cd \"\$dir\" && \\
  go mod download && \\
  go build ./... && \\
  go test -count=1 -run='^\$' ./...)
\`\`\`

- \`-run='^\$'\` matches no test names → zero test bodies execute (fast, can't fail on flaky tests)
- \`-count=1\` disables the test cache so compilation always runs (the tracer needs to observe it)
- \`./...\` compiles every test binary in the module

This is the same two-pass pattern used by upstream \`codeql-action\`'s Go autobuild (\`go build\` followed by test compilation).

## Cost

- \`Analyze (go)\` job time: roughly doubles for the Manual build step (test compile time ≈ build compile time). Total job ~3min → ~5min, well inside the 30-min timeout.
- Same \`init()\` exposure as the existing \`make test-all\` job already has on every PR. No new risk.

## Test plan

- [ ] After merge, security tab → CodeQL view shows Go at 143/143 (or very close) instead of 77/143
- [ ] \`Analyze (go)\` still passes; log shows \`go test\` compilation per module
- [ ] First post-merge scheduled run (Mon 06:23 UTC) reports findings against the full source including tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)