### PR TITLE
fix(codeql): run plain go test so test files get extracted

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,17 +49,27 @@ jobs:
       # the root finds nothing. Walk each module's go.mod and build it
       # under CodeQL's tracer so every package gets extracted.
       #
-      # `go build ./...` compiles production code only — *_test.go files
-      # are skipped, leaving ~46% of this repo's Go source unscanned.
-      # `go test -count=1 -run='^$' ./...` compiles every test binary
-      # (tracer captures the compiles) but the empty-regex `-run`
-      # filter executes no test bodies. `-count=1` disables the test
-      # cache so compilation always happens. This mirrors upstream
-      # codeql-action autobuild's two-pass behavior.
-      #
       # CodeQL bundles its own Go SDK and prepends it to PATH, so no
       # actions/setup-go step is needed. Autobuild handles `go mod
       # download` automatically; manual mode has to do it explicitly.
+      #
+      # `go build ./...` compiles production code only; *_test.go files
+      # are skipped, leaving roughly half this repo's Go source unscanned.
+      # `go test ./...` is what triggers the CodeQL extractor's
+      # test-extraction mode (the extractor inspects the intercepted
+      # command name: build/install/run extract production only, test
+      # extracts both).
+      #
+      # Subtle: the test command MUST NOT pass any `go test`-specific
+      # flags (-count, -run, -list, etc.). The extractor's mimic mode
+      # forwards captured flags to an internal `go list -test=true`
+      # invocation; `go list` rejects test-only flags with "flag
+      # provided but not defined", and the test-extraction pass silently
+      # aborts (the build-only pass still succeeds, so the database ends
+      # up with production files only — exactly the 77/143 symptom).
+      # Pipe stdout to /dev/null and `|| true` so a flaky/long test
+      # doesn't fail the security scan; the existing test job already
+      # gates correctness.
       - name: Manual build (Go)
         if: matrix.language == 'go'
         shell: bash
@@ -77,7 +87,7 @@ jobs:
             (cd "$dir" && \
               go mod download && \
               go build ./... && \
-              go test -count=1 -run='^$' ./...)
+              go test ./... > /dev/null 2>&1 || true)
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## Summary

The Security tab still reports Go at **77/143 files scanned** because PR #808's test-compile pass uses flags (\`-count=1 -run='^\$'\`) that break the CodeQL extractor's mimic mode. The build-tracer log on the post-merge main run shows:

\`\`\`
Running packages.Load (test extraction enabled).
...
Error running go tooling: err: exit status 2:
  stderr: flag provided but not defined: -count
\`\`\`

When the extractor intercepts \`go test\`, it forwards the captured flags to an internal \`go list -test=true\` invocation. \`go list\` doesn't accept \`-count\`, \`-run\`, or \`-list\`. The test-extraction pass aborts; the prior \`go build\` pass already finished, so the database silently ends up with production files only — exactly the 77/143 symptom.

## Locally reproduced

CodeQL CLI v2.25.5 (same version codeql-action@v3.35.5 ships), on \`receiver/githubreceiver\` (16 prod + 16 test = 32 \`.go\` files):

| Build command | .go in db | _test.go in db |
|---|---|---|
| \`go build ./...\` | 16 | 0 |
| \`go build ./... && go test -count=1 -run='^\$' ./...\` (PR #808's command) | 16 | 0 |
| same + \`CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS=true\` (PR #809's previous attempt) | 16 | 0 |
| **\`go build ./... && go test ./...\`** | **32** | **16** |

## The fix

Restore the test compile pass from PR #808's *intent*, but with no \`go test\` flags:

\`\`\`bash
(cd \"\$dir\" && \\
  go mod download && \\
  go build ./... && \\
  go test ./... > /dev/null 2>&1 || true)
\`\`\`

Tests do execute under this command. The existing \`test (1.24)\` job is the correctness gate; this invocation is purely to drive extraction. Stdout/stderr redirection + \`|| true\` ensure a flaky or slow test can't fail the security scan.

Note: an earlier version of this PR added \`CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS\` as an env var. That env var has no effect under build tracing — the extractor's mimic-mode \`parseFlags\` auto-sets \`extractTests=true\` whenever it sees an intercepted \`go test\` command. The env var only matters for direct CLI invocations of the extractor binary, which is not how codeql-action invokes it. Reverted.

## Cost

\`Analyze (go)\` job time goes from ~3min back to ~5min (similar to post-#808 timing). The tests actually run this time (vs the no-op \`-run='^\$'\` filter we used before), but that was a no-op only because the extractor immediately aborted; the wall-clock work was happening anyway.

## Test plan

- [ ] CI on this PR completes successfully
- [ ] After merge, Security tab → CodeQL → Scanned files reports Go at ~143/143
- [ ] \`results_count\` on the post-merge \`/language:go\` analysis likely grows past 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)