### PR TITLE
fix(renovate): group otel collector core/contrib deps into one update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,18 @@
         "gomod",
         "ocb"
       ],
+      "matchPackageNames": [
+        "go.opentelemetry.io/collector**",
+        "github.com/open-telemetry/opentelemetry-collector-contrib/**"
+      ],
+      "groupName": "otel collector core & contrib deps",
+      "description": "OCB requires every component compiled into the distribution to share a compatible core collector version, so all go.opentelemetry.io/collector* and opentelemetry-collector-contrib/* deps (across manifest.yaml and every component go.mod) must be bumped together, not one-at-a-time"
+    },
+    {
+      "matchManagers": [
+        "gomod",
+        "ocb"
+      ],
       "matchFileNames": [
         "receiver/**",
         "go.mod"

--- a/renovate.json
+++ b/renovate.json
@@ -48,34 +48,6 @@
     },
     {
       "matchManagers": [
-        "gomod",
-        "ocb"
-      ],
-      "matchPackageNames": [
-        "go.opentelemetry.io/collector**",
-        "github.com/open-telemetry/opentelemetry-collector-contrib/**"
-      ],
-      "groupName": "otel collector core & contrib deps",
-      "description": "OCB requires every component compiled into the distribution to share a compatible core collector version, so all go.opentelemetry.io/collector* and opentelemetry-collector-contrib/* deps (across manifest.yaml and every component go.mod) must be bumped together, not one-at-a-time"
-    },
-    {
-      "matchManagers": [
-        "gomod",
-        "ocb"
-      ],
-      "matchFileNames": [
-        "receiver/**",
-        "go.mod"
-      ],
-      "matchPackageNames": [
-        "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen",
-        "go.opentelemetry.io/collector/cmd/builder"
-      ],
-      "groupName": "collector component deps",
-      "description": "Groups together all dependencies on collector components"
-    },
-    {
-      "matchManagers": [
         "gomod"
       ],
       "matchFileNames": [
@@ -93,6 +65,18 @@
       ],
       "groupName": "otel-compgen cmd deps",
       "description": "Groups together all dependencies of the otel-compgen utility"
+    },
+    {
+      "matchManagers": [
+        "gomod",
+        "ocb"
+      ],
+      "matchPackageNames": [
+        "go.opentelemetry.io/collector**",
+        "github.com/open-telemetry/opentelemetry-collector-contrib/**"
+      ],
+      "groupName": "otel collector core & contrib deps",
+      "description": "OCB requires every component compiled into the distribution, plus the mdatagen/builder tools used to generate and assemble it, to share a compatible core collector version. All go.opentelemetry.io/collector* and opentelemetry-collector-contrib/* deps (across manifest.yaml, every component go.mod, and internal/tools/go.mod's mdatagen/builder) must move in lockstep, not one-at-a-time. Placed last so it overrides the generic 'tool deps' grouping for mdatagen/builder specifically."
     }
   ],
   "prConcurrentLimit": 10,


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry grouping every `go.opentelemetry.io/collector*` and `github.com/open-telemetry/opentelemetry-collector-contrib/*` dependency (across the `ocb` manager on `config/manifest.yaml`, the `gomod` manager on every component `go.mod`, **and** `internal/tools/go.mod`'s `mdatagen`/`builder`) into a single Renovate update group, `otel collector core & contrib deps`.
- Removes the old `collector component deps` packageRule, which was dead code: its `matchPackageNames` used the wrong import path for `mdatagen` (`opentelemetry-collector-contrib/cmd/mdatagen` instead of the real `go.opentelemetry.io/collector/cmd/mdatagen`) and its `matchFileNames` omitted `internal/tools/**`, where `mdatagen`/`builder` actually live. So both tools fell through into the generic `tool deps` rule and got bumped independently of the core/contrib pin.
- Places the new group last in `packageRules` so it wins (last-match-overrides-groupName) over the generic `tool deps` rule specifically for `mdatagen`/`builder`, without touching any other tool-deps grouping (golangci-lint, osv-scanner, gosec, etc.).

## Why
OCB requires every component compiled into the distribution — plus the `mdatagen`/`builder` tools used to generate and assemble it — to share a compatible core `go.opentelemetry.io/collector` version. Renovate was proposing ~90 of these deps one-at-a-time; each individual bump is unbuildable on its own (confirmed via open PRs #791/#795 failing `make build` on an `exporterhelper.WithQueue` signature change), so they never merge and pile up in the Dependency Dashboard's "Awaiting Schedule" section (issue #5).

Separately, `mdatagen`/`builder` drifting ahead of the core/contrib pin (because the old grouping rule silently never matched) is the confirmed direct cause of PR #780's CI failures: `mdatagen` v0.155 changed the `metadata.yaml` schema (breaking `make generate`), and `builder` assembled a distribution requiring v0.155-compatible core APIs while every component stayed pinned at v0.141.0 (breaking `make build`). This PR puts `mdatagen`/`builder` in the same lockstep group as the rest of the collector core/contrib deps so that can't recur.

## Test plan
- [ ] `python3 -m json.tool renovate.json` — valid JSON (done locally)
- [ ] Confirm on Renovate's next run that the grouped PR is created and covers manifest.yaml + every component go.mod + internal/tools' mdatagen/builder, without duplicating the `tool deps` group
- [ ] Review whether the glob patterns (`go.opentelemetry.io/collector**`, `.../opentelemetry-collector-contrib/**`) need narrowing/broadening once the first grouped PR is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)