### PR TITLE
fix: incorrect glob patterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,8 @@
         "ocb"
       ],
       "matchPackageNames": [
-        "go.opentelemetry.io/collector**",
+        "go.opentelemetry.io/collector",
+        "go.opentelemetry.io/collector/**",
         "github.com/open-telemetry/opentelemetry-collector-contrib/**"
       ],
       "groupName": "otel collector core & contrib deps",


### PR DESCRIPTION
`collector**` doesn't match on descendants so we need both `collector` and `collector/**`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency grouping rules so OpenTelemetry Collector packages are matched more precisely, improving how related updates are organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->