### PR TITLE
feat(gitlabreceiver): key vcs.ref.lines_delta by vcs.change.id (Approach A)

### DIFF
--- a/receiver/gitlabreceiver/documentation.md
+++ b/receiver/gitlabreceiver/documentation.md
@@ -171,6 +171,7 @@ The number of lines added/removed in a ref (branch) relative to the default bran
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
+| vcs.change.id | The unique identifier of the VCS change (pull request). | Any Str | Recommended | - |
 | vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended | - |
 | vcs.repository.name | The name of the VCS repository. | Any Str | Recommended | - |
 | vcs.repository.id | The unique identifier of the VCS repository. | Any Str | Recommended | - |

--- a/receiver/gitlabreceiver/generated_package_test.go
+++ b/receiver/gitlabreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package gitlabreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/gitlabreceiver/generated_package_test.go
+++ b/receiver/gitlabreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package gitlabreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/gitlabreceiver/internal/metadata/generated_config.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_config.go
@@ -516,6 +516,7 @@ func (ms *VcsRefCountMetricConfig) Validate() error {
 type VcsRefLinesDeltaMetricAttributeKey string
 
 const (
+	VcsRefLinesDeltaMetricAttributeKeyVcsChangeID          VcsRefLinesDeltaMetricAttributeKey = "vcs.change.id"
 	VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull VcsRefLinesDeltaMetricAttributeKey = "vcs.repository.url.full"
 	VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName    VcsRefLinesDeltaMetricAttributeKey = "vcs.repository.name"
 	VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID      VcsRefLinesDeltaMetricAttributeKey = "vcs.repository.id"
@@ -550,9 +551,9 @@ func (ms *VcsRefLinesDeltaMetricConfig) Unmarshal(parser *confmap.Conf) error {
 func (ms *VcsRefLinesDeltaMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType:
+		case VcsRefLinesDeltaMetricAttributeKeyVcsChangeID, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType:
 		default:
-			return fmt.Errorf("metric vcs.ref.lines_delta doesn't have an attribute %v, valid attributes: [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]", val)
+			return fmt.Errorf("metric vcs.ref.lines_delta doesn't have an attribute %v, valid attributes: [vcs.change.id, vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]", val)
 		}
 	}
 
@@ -886,7 +887,7 @@ func DefaultMetricsConfig() MetricsConfig {
 		VcsRefLinesDelta: VcsRefLinesDeltaMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
+			EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsChangeID, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
 		},
 		VcsRefRevisionsDelta: VcsRefRevisionsDeltaMetricConfig{
 			Enabled:             true,

--- a/receiver/gitlabreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_config_test.go
@@ -79,7 +79,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					VcsRefLinesDelta: VcsRefLinesDeltaMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
+						EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsChangeID, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
 					},
 					VcsRefRevisionsDelta: VcsRefRevisionsDeltaMetricConfig{
 						Enabled:             true,
@@ -171,7 +171,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					VcsRefLinesDelta: VcsRefLinesDeltaMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
+						EnabledAttributes:   []VcsRefLinesDeltaMetricAttributeKey{VcsRefLinesDeltaMetricAttributeKeyVcsChangeID, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryName, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryID, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadName, VcsRefLinesDeltaMetricAttributeKeyVcsRefHeadType, VcsRefLinesDeltaMetricAttributeKeyVcsLineChangeType},
 					},
 					VcsRefRevisionsDelta: VcsRefRevisionsDeltaMetricConfig{
 						Enabled:             false,
@@ -340,7 +340,7 @@ func TestVcsRefLinesDeltaMetricsConfig_Validate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []VcsRefLinesDeltaMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric vcs.ref.lines_delta doesn't have an attribute invalid, valid attributes: [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]")
+	require.ErrorContains(t, cfg.Validate(), "metric vcs.ref.lines_delta doesn't have an attribute invalid, valid attributes: [vcs.change.id, vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]")
 
 	cfg = DefaultMetricsConfig().VcsRefLinesDelta
 	cfg.AggregationStrategy = "invalid"

--- a/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
@@ -3,15 +3,14 @@
 package metadata
 
 import (
-	"slices"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
+	"slices"
+	"time"
 )
 
 const (
@@ -168,7 +167,7 @@ var MetricsInfo = metricsInfo{
 	},
 	VcsRefLinesDelta: metricInfo{
 		Name:       "vcs.ref.lines_delta",
-		Attributes: []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.repository.id", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.line_change.type"},
+		Attributes: []string{"vcs.change.id", "vcs.repository.url.full", "vcs.repository.name", "vcs.repository.id", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.line_change.type"},
 	},
 	VcsRefRevisionsDelta: metricInfo{
 		Name:       "vcs.ref.revisions_delta",
@@ -1195,7 +1194,7 @@ func (m *metricVcsRefLinesDelta) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsLineChangeTypeAttributeValue string) {
+func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsChangeIDAttributeValue string, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsLineChangeTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1203,6 +1202,9 @@ func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, VcsRefLinesDeltaMetricAttributeKeyVcsChangeID) {
+		dp.Attributes().PutStr("vcs.change.id", vcsChangeIDAttributeValue)
+	}
 	if slices.Contains(m.config.EnabledAttributes, VcsRefLinesDeltaMetricAttributeKeyVcsRepositoryURLFull) {
 		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
 	}
@@ -2030,8 +2032,8 @@ func (mb *MetricsBuilder) RecordVcsRefCountDataPoint(ts pcommon.Timestamp, val i
 }
 
 // RecordVcsRefLinesDeltaDataPoint adds a data point to vcs.ref.lines_delta metric.
-func (mb *MetricsBuilder) RecordVcsRefLinesDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsLineChangeTypeAttributeValue AttributeVcsLineChangeType) {
-	mb.metricVcsRefLinesDelta.recordDataPoint(mb.startTime, ts, val, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsLineChangeTypeAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcsRefLinesDeltaDataPoint(ts pcommon.Timestamp, val int64, vcsChangeIDAttributeValue string, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRepositoryIDAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue AttributeVcsRefHeadType, vcsLineChangeTypeAttributeValue AttributeVcsLineChangeType) {
+	mb.metricVcsRefLinesDelta.recordDataPoint(mb.startTime, ts, val, vcsChangeIDAttributeValue, vcsRepositoryURLFullAttributeValue, vcsRepositoryNameAttributeValue, vcsRepositoryIDAttributeValue, vcsRefHeadNameAttributeValue, vcsRefHeadTypeAttributeValue.String(), vcsLineChangeTypeAttributeValue.String())
 }
 
 // RecordVcsRefRevisionsDeltaDataPoint adds a data point to vcs.ref.revisions_delta metric.

--- a/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_metrics.go
@@ -3,14 +3,15 @@
 package metadata
 
 import (
+	"slices"
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
-	"slices"
-	"time"
 )
 
 const (

--- a/receiver/gitlabreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/gitlabreceiver/internal/metadata/generated_metrics_test.go
@@ -152,9 +152,9 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcsRefLinesDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsLineChangeTypeAdded)
+			mb.RecordVcsRefLinesDeltaDataPoint(ts, 1, "vcs.change.id-val", "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.repository.id-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, AttributeVcsLineChangeTypeAdded)
 			if tt.name == "reaggregate_set" {
-				mb.RecordVcsRefLinesDeltaDataPoint(ts, 3, "vcs.repository.url.full-val-2", "vcs.repository.name-val-2", "vcs.repository.id-val-2", "vcs.ref.head.name-val-2", AttributeVcsRefHeadTypeTag, AttributeVcsLineChangeTypeRemoved)
+				mb.RecordVcsRefLinesDeltaDataPoint(ts, 3, "vcs.change.id-val-2", "vcs.repository.url.full-val-2", "vcs.repository.name-val-2", "vcs.repository.id-val-2", "vcs.ref.head.name-val-2", AttributeVcsRefHeadTypeTag, AttributeVcsLineChangeTypeRemoved)
 			}
 			defaultMetricsCount++
 			allMetricsCount++
@@ -763,6 +763,9 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
+						vcsChangeIDAttrVal, ok := dp.Attributes().Get("vcs.change.id")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.change.id-val", vcsChangeIDAttrVal.Str())
 						vcsRepositoryURLFullAttrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
 						assert.True(t, ok)
 						assert.Equal(t, "vcs.repository.url.full-val", vcsRepositoryURLFullAttrVal.Str())
@@ -802,7 +805,9 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						_, ok := dp.Attributes().Get("vcs.change.id")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.url.full")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("vcs.repository.name")
 						assert.False(t, ok)

--- a/receiver/gitlabreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/gitlabreceiver/internal/metadata/testdata/config.yaml
@@ -33,7 +33,7 @@ all_set:
       attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.type"]
     vcs.ref.lines_delta:
       enabled: true
-      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.line_change.type"]
+      attributes: ["vcs.change.id","vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.line_change.type"]
     vcs.ref.revisions_delta:
       enabled: true
       attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.revision_delta.direction"]
@@ -145,7 +145,7 @@ none_set:
       attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.type"]
     vcs.ref.lines_delta:
       enabled: false
-      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.line_change.type"]
+      attributes: ["vcs.change.id","vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.line_change.type"]
     vcs.ref.revisions_delta:
       enabled: false
       attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.repository.id","vcs.ref.head.name","vcs.ref.head.type","vcs.revision_delta.direction"]

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -189,9 +189,9 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 			for _, mr := range mrs {
 				//nolint:lll
-				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Additions), url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeAdded)
+				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Additions), mr.Iid, url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeAdded)
 				//nolint:lll
-				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Deletions), url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeRemoved)
+				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Deletions), mr.Iid, url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeRemoved)
 
 				// Checks if the merge request has been merged. This is done with IsZero() which tells us if the
 				// time is or isn't  January 1, year 1, 00:00:00 UTC, which is what null in graphql date values

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
@@ -85,8 +85,11 @@ resourceMetrics:
           - description: The number of lines added/removed in a ref (branch) relative to the default branch (trunk).
             gauge:
               dataPoints:
-                - asInt: "15"
+                - asInt: "10"
                   attributes:
+                    - key: vcs.change.id
+                      value:
+                        stringValue: "1"
                     - key: vcs.line_change.type
                       value:
                         stringValue: added
@@ -107,8 +110,61 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "6"
+                - asInt: "5"
                   attributes:
+                    - key: vcs.change.id
+                      value:
+                        stringValue: "1"
+                    - key: vcs.line_change.type
+                      value:
+                        stringValue: removed
+                    - key: vcs.ref.head.name
+                      value:
+                        stringValue: feature-a
+                    - key: vcs.ref.head.type
+                      value:
+                        stringValue: branch
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
+                    - key: vcs.repository.name
+                      value:
+                        stringValue: project
+                    - key: vcs.repository.url.full
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "20"
+                  attributes:
+                    - key: vcs.change.id
+                      value:
+                        stringValue: "2"
+                    - key: vcs.line_change.type
+                      value:
+                        stringValue: added
+                    - key: vcs.ref.head.name
+                      value:
+                        stringValue: feature-a
+                    - key: vcs.ref.head.type
+                      value:
+                        stringValue: branch
+                    - key: vcs.repository.id
+                      value:
+                        stringValue: "1"
+                    - key: vcs.repository.name
+                      value:
+                        stringValue: project
+                    - key: vcs.repository.url.full
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: vcs.change.id
+                      value:
+                        stringValue: "2"
                     - key: vcs.line_change.type
                       value:
                         stringValue: removed

--- a/receiver/gitlabreceiver/metadata.yaml
+++ b/receiver/gitlabreceiver/metadata.yaml
@@ -163,7 +163,7 @@ metrics:
     unit: '{line}'
     gauge:
       value_type: int
-    attributes: [vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]
+    attributes: [vcs.change.id, vcs.repository.url.full, vcs.repository.name, vcs.repository.id, vcs.ref.head.name, vcs.ref.head.type, vcs.line_change.type]
   vcs.ref.revisions_delta:
     enabled: true
     description: The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).


### PR DESCRIPTION
## Approach A of 2 — key `vcs.ref.lines_delta` by `vcs.change.id`

> **This is one of two competing PRs** solving the same `vcs.ref.lines_delta` regression. The team should merge **one** and close the other. Companion: **Approach B** (`fix/gitlab-lines-delta-per-branch`) — aggregates per branch in the scraper instead.

Targets the renovate branch (`renovate/otel-collector-core-and-contrib-deps`, PR #811), which already carries the v0.156.0 breaking-change fixes and the MR-state mock fix. **This PR contains only the `vcs.ref.lines_delta` fix itself** (plus a follow-on commit normalizing generated-import grouping so the `generate` CI job stays green).

### The problem

The otel-collector v0.156.0 bump regenerated the mdatagen metrics builder, which now **merges datapoints that share an identical attribute-set + timestamp**, combining their values by an `aggregation_strategy` (gauges default to **avg**).

`vcs.ref.lines_delta` is recorded once per merge-request, per `{added, removed}`, keyed on the MR's **source branch** (`vcs.ref.head.name`) — its attribute set contains **no change/MR identifier**. So when two MRs share a source branch, their datapoints collide on identity and the builder silently **averages** them. With the test's two MRs on branch `feature-a` (additions 10 and 20), the emitted value became `avg(10,20) = 15`, and `avg(5,8)` int-truncated to `6` — data loss, not a rounding quirk.

### This approach

Add `vcs.change.id` to the `vcs.ref.lines_delta` attribute set (as the change.* metrics already do) so each MR's datapoint stays distinct. No averaging; every MR's real diff-stat is preserved.

- `metadata.yaml`: add `vcs.change.id` to the metric's `attributes`.
- Regenerated the metadata code (`mdatagen`); `RecordVcsRefLinesDeltaDataPoint` gains a change-id parameter.
- `gitlab_scraper.go`: pass `mr.Iid` at both record sites.

**Result** — `vcs.ref.lines_delta` emits 4 distinct datapoints:

| change.id | type | value |
|---|---|---|
| 1 | added | 10 |
| 1 | removed | 5 |
| 2 | added | 20 |
| 2 | removed | 8 |

### Why this is the spec-aligned choice

The canonical OpenTelemetry semantic-conventions registry (`model/vcs/metrics.yaml`, present since **v1.30.0**, unchanged on `main`) defines `vcs.ref.lines_delta` **with** `vcs.change.id` at `requirement_level: conditionally_required: "if a change is associated with the ref."` Every datapoint this scraper emits is derived per-MR from `mr.DiffStatsSummary`, so a change is **always** associated with the ref — the condition is met, and keying by `vcs.change.id` is exactly what the spec prescribes.

(Upstream contrib's `githubreceiver` omits this attribute, but that reads as an implementation gap rather than authority — the registry has required it conditionally since the vcs namespace was introduced.)

### Verification
- `go build ./...`, `go vet ./...`, `go test ./...` across the `gitlabreceiver` module — all pass.
- `golangci-lint run ./...` — 0 issues.
- `TestScrape` golden regenerated; 4 datapoints confirmed with the exact values above.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
