### PR TITLE
feat(gitlabreceiver): aggregate vcs.ref.lines_delta per branch (Approach B)

### DIFF
--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/gitlab_scraper.go
@@ -187,11 +187,28 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 			gls.mb.RecordVcsContributorCountDataPoint(now, int64(contributorCount), url, path, projectID)
 			// gls.mb.RecordVcsRepositoryContributorCountDataPoint(now, int64(contributorCount), path)
 
+			// vcs.ref.lines_delta is a per-branch (ref-vs-trunk) quantity, not a
+			// per-MR one, but multiple MRs can share a source branch. Aggregate
+			// additions/deletions per branch across all MRs before recording so
+			// each branch produces exactly one datapoint per line-change-type,
+			// rather than relying on the metrics builder's lossy avg-merge of
+			// same-identity datapoints.
+			type lineDelta struct {
+				additions int
+				deletions int
+			}
+			lineDeltaByBranch := make(map[string]*lineDelta)
+			var branchOrder []string
+
 			for _, mr := range mrs {
-				//nolint:lll
-				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Additions), url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeAdded)
-				//nolint:lll
-				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(mr.DiffStatsSummary.Deletions), url, path, projectID, mr.SourceBranch, refType, metadata.AttributeVcsLineChangeTypeRemoved)
+				delta, ok := lineDeltaByBranch[mr.SourceBranch]
+				if !ok {
+					delta = &lineDelta{}
+					lineDeltaByBranch[mr.SourceBranch] = delta
+					branchOrder = append(branchOrder, mr.SourceBranch)
+				}
+				delta.additions += mr.DiffStatsSummary.Additions
+				delta.deletions += mr.DiffStatsSummary.Deletions
 
 				// Checks if the merge request has been merged. This is done with IsZero() which tells us if the
 				// time is or isn't  January 1, year 1, 00:00:00 UTC, which is what null in graphql date values
@@ -203,6 +220,14 @@ func (gls *gitlabScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 					mergedAge := int64(mr.MergedAt.Sub(mr.CreatedAt).Seconds())
 					gls.mb.RecordVcsChangeTimeToMergeDataPoint(now, mergedAge, mr.Iid, url, path, projectID, mr.SourceBranch)
 				}
+			}
+
+			for _, branch := range branchOrder {
+				delta := lineDeltaByBranch[branch]
+				//nolint:lll
+				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(delta.additions), url, path, projectID, branch, refType, metadata.AttributeVcsLineChangeTypeAdded)
+				//nolint:lll
+				gls.mb.RecordVcsRefLinesDeltaDataPoint(now, int64(delta.deletions), url, path, projectID, branch, refType, metadata.AttributeVcsLineChangeTypeRemoved)
 			}
 			mux.Unlock()
 		}()

--- a/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
+++ b/receiver/gitlabreceiver/internal/scraper/gitlabscraper/testdata/scraper/expected_happy_path.yaml
@@ -85,7 +85,7 @@ resourceMetrics:
           - description: The number of lines added/removed in a ref (branch) relative to the default branch (trunk).
             gauge:
               dataPoints:
-                - asInt: "15"
+                - asInt: "30"
                   attributes:
                     - key: vcs.line_change.type
                       value:
@@ -107,7 +107,7 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "6"
+                - asInt: "13"
                   attributes:
                     - key: vcs.line_change.type
                       value:


### PR DESCRIPTION
## Approach B of 2 — aggregate `vcs.ref.lines_delta` per branch in the scraper

> **This is one of two competing PRs** solving the same `vcs.ref.lines_delta` regression. The team should merge **one** and close the other. Companion: **Approach A** (`fix/gitlab-lines-delta-change-id`) — keys datapoints by `vcs.change.id` instead. **See the semconv note below — the evidence currently favors Approach A.**

Targets the renovate branch (`renovate/otel-collector-core-and-contrib-deps`, PR #811), which already carries the v0.156.0 breaking-change fixes and the MR-state mock fix. **This PR contains only the `vcs.ref.lines_delta` fix itself** — a single scraper-only commit.

### The problem

The otel-collector v0.156.0 bump regenerated the mdatagen metrics builder, which now **merges datapoints that share an identical attribute-set + timestamp**, combining their values by an `aggregation_strategy` (gauges default to **avg**).

`vcs.ref.lines_delta` is recorded once per merge-request, per `{added, removed}`, keyed on the MR's **source branch** (`vcs.ref.head.name`), with no change/MR identifier in its attribute set. When two MRs share a source branch, their datapoints collide and the builder silently **averages** them (e.g. `avg(10,20)=15`; `avg(5,8)` truncates to `6`) — data loss.

### This approach

Treat `vcs.ref.lines_delta` as a deliberate **per-branch rollup**: sum each branch's MR diff-stats in the scraper and record **one** datapoint per branch per line-change-type. No reliance on the builder's merge, and — notably — no `metadata.yaml` or generated-code change.

> Note: the `aggregation_strategy` field is a **runtime, end-user** config knob in mdatagen v0.156.0 with a hardcoded default (avg for gauges); it is **not** a component-author `metadata.yaml` setting, so the fix has to be scraper-side.

- `gitlab_scraper.go`: accumulate additions/deletions into a `map[branch]` inside the existing per-MR loop, then record once per branch. `vcs.change.duration` / `vcs.change.time_to_merge` are untouched.

**Result** — `vcs.ref.lines_delta` emits 2 summed datapoints for `feature-a`:

| type | value |
|---|---|
| added | 30 (10 + 20) |
| removed | 13 (5 + 8) |

### Semantic caveat (read before choosing this over Approach A)

`vcs.ref.lines_delta` is documented as "lines added/removed in a ref (branch) **relative to the default branch (trunk)**" — a branch-vs-trunk **snapshot**, not a cumulative per-change counter. Summing an open MR and a later merged MR on the same source branch can **double-count** overlapping diff content if the merged MR's diff already supersedes the open one's.

Moreover, the OTel semconv registry models this metric as keyed by `vcs.change.id` (conditionally required "if a change is associated with the ref") — i.e. per-change, which is what Approach A implements. That is the stronger reason the evidence favors A; this PR is provided so the team can compare a genuine per-branch-rollup interpretation against it.

### Verification
- `go build ./...`, `go vet ./...`, `go test ./...` across the `gitlabreceiver` module — all pass.
- `golangci-lint run ./...` — 0 issues.
- `TestScrape` golden regenerated; 2 summed datapoints confirmed. Scraper-only diff (no metadata/generated changes).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
