### PR TITLE
feat: add /regenerate slash command workflow

### DIFF
--- a/.github/chainguard/regenerate.sts.yaml
+++ b/.github/chainguard/regenerate.sts.yaml
@@ -1,0 +1,10 @@
+---
+# Identity assumed by the /regenerate slash-command workflow so it can push
+# generated code back to a PR branch. issue_comment workflows always run in the
+# context of the default branch, so the subject is pinned to refs/heads/main.
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:liatrio/liatrio-otel-collector:ref:refs/heads/main
+
+permissions:
+  contents: write
+  pull-requests: write

--- a/.github/chainguard/regenerate.sts.yaml
+++ b/.github/chainguard/regenerate.sts.yaml
@@ -7,4 +7,4 @@ subject_pattern: repo:liatrio/liatrio-otel-collector:ref:refs/heads/main
 
 permissions:
   contents: write
-  pull-requests: write
+  pull_requests: write

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -23,6 +23,10 @@ jobs:
       github.event.comment.body == '/regenerate' &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    # Defense in depth for this privileged issue_comment workflow: configure the
+    # `regenerate` environment with required reviewers so each run that checks
+    # out and executes PR-provided code is approved by a maintainer.
+    environment: regenerate
     permissions:
       contents: read
       id-token: write
@@ -50,9 +54,10 @@ jobs:
         run: |
           gh pr view "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" \
-            --json headRefName,isCrossRepository \
+            --json headRefName,headRefOid,isCrossRepository \
             > pr.json
           echo "head_ref=$(jq -r .headRefName pr.json)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(jq -r .headRefOid pr.json)" >> "$GITHUB_OUTPUT"
           echo "is_fork=$(jq -r .isCrossRepository pr.json)" >> "$GITHUB_OUTPUT"
 
       - name: Reject fork PRs
@@ -68,7 +73,9 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ steps.pr.outputs.head_ref }}
+          # Pin to the exact SHA resolved above rather than the mutable branch
+          # ref, so what runs is what was gated (no time-of-check/time-of-use gap).
+          ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
           token: ${{ steps.octo-sts.outputs.token }}
 
@@ -93,9 +100,14 @@ jobs:
       - name: Commit and push changes
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          # Referenced via the environment (not interpolated into the script) so
+          # a crafted branch name can't inject shell commands.
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
           set -eo pipefail
-          if git diff --quiet; then
+          # --untracked-files=all so newly generated (untracked) files count as
+          # changes; `git diff --quiet` only looks at tracked files.
+          if [ -z "$(git status --porcelain=v1 --untracked-files=all)" ]; then
             echo "No changes produced by make generate."
             gh pr comment "${{ github.event.issue.number }}" \
               --repo "${{ github.repository }}" \
@@ -106,7 +118,7 @@ jobs:
           git config user.email '${{ steps.get-user-id.outputs.user-id }}+octo-sts[bot]@users.noreply.github.com'
           git add -A
           git commit -m "chore: run make generate"
-          git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"
+          git push origin "HEAD:${HEAD_REF}"
           gh pr comment "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" \
             --body ":white_check_mark: Committed regenerated code to this PR."

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,0 +1,112 @@
+---
+name: regenerate
+
+# Comment `/regenerate` on a PR to check out its head branch, run
+# `make generate`, and commit any resulting changes back to the branch.
+on:
+  issue_comment:
+    types: [created]
+
+# Only one regenerate run per PR at a time; a newer comment cancels an
+# in-flight run for the same PR.
+concurrency:
+  group: regenerate-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: regenerate
+    # Gate on: comment is on a PR, body is exactly `/regenerate`, and the
+    # commenter has write access (owner/member/collaborator).
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/regenerate' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Get Octo STS Token
+        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: regenerate
+
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          gh api -X POST \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes
+
+      - name: Get PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefName,isCrossRepository \
+            > pr.json
+          echo "head_ref=$(jq -r .headRefName pr.json)" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$(jq -r .isCrossRepository pr.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Reject fork PRs
+        if: steps.pr.outputs.is_fork == 'true'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body ":warning: \`/regenerate\` can't push to a fork's branch. Please run \`make generate\` locally and push the changes yourself."
+          exit 1
+
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.pr.outputs.head_ref }}
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Make install-tools
+        run: make install-tools
+
+      - name: Make generate
+        run: make generate
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: echo "user-id=$(gh api "/users/octo-sts[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          set -eo pipefail
+          if git diff --quiet; then
+            echo "No changes produced by make generate."
+            gh pr comment "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --body ":white_check_mark: \`make generate\` produced no changes — the PR is already up to date."
+            exit 0
+          fi
+          git config user.name 'octo-sts[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+octo-sts[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "chore: run make generate"
+          git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body ":white_check_mark: Committed regenerated code to this PR."

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -1,8 +1,13 @@
 ---
 name: regenerate
 
-# Comment `/regenerate` on a PR to check out its head branch, run
-# `make generate`, and commit any resulting changes back to the branch.
+# Lets a maintainer comment `/regenerate` on a Renovate PR to re-run
+# `make generate` and commit the result back to the branch.
+#
+# Hosted Renovate can't run post-upgrade hooks, so dependency bumps that
+# change generated code land with stale output and fail CI. Rather than
+# pulling the branch down locally to regenerate and push back, a maintainer
+# comments `/regenerate` and this workflow does it for them.
 on:
   issue_comment:
     types: [created]
@@ -16,17 +21,23 @@ concurrency:
 jobs:
   regenerate:
     name: regenerate
-    # Gate on: comment is on a PR, body is exactly `/regenerate`, and the
-    # commenter has write access (owner/member/collaborator).
+    # Gate on ALL of:
+    #   - the comment is on a PR,
+    #   - its body is exactly `/regenerate`,
+    #   - the PR was opened by Renovate, and
+    #   - the commenter has write access (owner/member/collaborator).
+    #
+    # Scoping to Renovate-authored PRs is the security boundary: Renovate
+    # pushes its branches to this repo (never a fork), so the code we check
+    # out and execute is always a same-repo dependency bump — the very code
+    # the build-and-test workflow already runs on every push to the branch.
+    # An arbitrary contributor's PR can never reach this job.
     if: >-
       github.event.issue.pull_request &&
       github.event.comment.body == '/regenerate' &&
+      github.event.issue.user.login == 'renovate[bot]' &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
-    # Defense in depth for this privileged issue_comment workflow: configure the
-    # `regenerate` environment with required reviewers so each run that checks
-    # out and executes PR-provided code is approved by a maintainer.
-    environment: regenerate
     permissions:
       contents: read
       id-token: write
@@ -47,35 +58,19 @@ jobs:
             "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=eyes
 
-      - name: Get PR metadata
+      - name: Get PR branch
         id: pr
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
-          gh pr view "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" \
-            --json headRefName,headRefOid,isCrossRepository \
-            > pr.json
-          echo "head_ref=$(jq -r .headRefName pr.json)" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(jq -r .headRefOid pr.json)" >> "$GITHUB_OUTPUT"
-          echo "is_fork=$(jq -r .isCrossRepository pr.json)" >> "$GITHUB_OUTPUT"
-
-      - name: Reject fork PRs
-        if: steps.pr.outputs.is_fork == 'true'
-        env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: |
-          gh pr comment "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" \
-            --body ":warning: \`/regenerate\` can't push to a fork's branch. Please run \`make generate\` locally and push the changes yourself."
-          exit 1
+          head_ref=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" --json headRefName --jq .headRefName)
+          echo "head_ref=${head_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Pin to the exact SHA resolved above rather than the mutable branch
-          # ref, so what runs is what was gated (no time-of-check/time-of-use gap).
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ steps.octo-sts.outputs.token }}
 


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that lets a maintainer comment `/regenerate` on a PR to:

- **a)** check out the PR's head branch
- **b)** run `make install-tools` + `make generate`
- **c)** commit and push any resulting changes back to the PR branch

## How it works

- **Trigger:** `issue_comment` where the body is exactly `/regenerate` and the commenter's `author_association` is `OWNER`/`MEMBER`/`COLLABORATOR` (blocks drive-by triggering).
- **Auth:** uses a dedicated least-privilege octo-sts identity (`.github/chainguard/regenerate.sts.yaml`, `contents: write` + `pull-requests: write`), matching the existing `multimod-prepare-release` pattern. This matters because commits pushed with the default `GITHUB_TOKEN` do **not** re-trigger CI — the App token does.
- **Feedback:** reacts 👀 to acknowledge, then comments the outcome (pushed / no changes / fork rejected).
- **Fork PRs:** rejected with a comment telling the author to run `make generate` locally, since the base-repo token can't push to a fork branch.
- **Concurrency:** a newer `/regenerate` cancels an in-flight run for the same PR.

## Notes

- Scoped to `make generate` only, as requested. CI separately checks `make tidy-all` and `make crosslink` — happy to add those if desired.
- The octo-sts identity file must merge to `main` before the App will honor it (`issue_comment` workflows run in the default-branch context, so `subject_pattern` is pinned to `refs/heads/main`, same as the existing `semantic-release` identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/regenerate` pull request command that automatically regenerates code and commits updates to the pull request branch.
  * Provides status notifications for regeneration progress, completion, and cases where no updates are needed.
  * Prevents regeneration for forked pull requests and provides instructions for running the process locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->