### PR TITLE
docs: add AGENTS.md agent guidance and semantic conventions policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ register, and the package-upgrade/OCB/Renovate runbook live in
   `make generate`, `make tidy-all`, and `make crosslink` and fails on any resulting diff — so keep
   generated code, module tidiness, and replace directives in sync.
 - Releases are automated on `main` via multimod + semantic versioning driven by `versions.yaml`
-  (the `liatrio-otel` module set).
+  (the `liatrio-otel` module set). Full pipeline in [`docs/releasing.md`](docs/releasing.md).
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,8 @@ Two independent codegen pipelines run from `//go:generate` directives (usually i
    `schema.graphql` (upstream API schema), `genqlient.graphql` (queries), `genqlient.yaml` (config +
    scalar bindings) — and generate `generated_graphql.go` / `generated.go`.
 
-CI fails if regenerating produces a diff, so **run `make generate` and commit the result** after
-touching any `metadata.yaml`, `.graphql`, or genqlient config. Editing templates in `cmd/otel-compgen`
+CI fails if regenerating produces a diff, so **run `make generate` and include the regenerated files
+in the same change** after touching any `metadata.yaml`, `.graphql`, or genqlient config. Editing templates in `cmd/otel-compgen`
 requires rebuilding that binary — templates are compiled in via `//go:embed`.
 
 ## Component architecture
@@ -167,7 +167,7 @@ register, and the package-upgrade/OCB/Renovate runbook live in
 - Lint config is `.golangci.yaml` (Go 1.24, line length 185). Formatting is `goimports` + `gofmt`.
 - CI (`.github/workflows/build.yml`) only runs real jobs on PRs targeting `main`. It re-runs
   `make generate`, `make tidy-all`, and `make crosslink` and fails on any resulting diff — so keep
-  generated code, module tidiness, and replace directives committed.
+  generated code, module tidiness, and replace directives in sync.
 - Releases are automated on `main` via multimod + semantic versioning driven by `versions.yaml`
   (the `liatrio-otel` module set).
 
@@ -178,7 +178,8 @@ register, and the package-upgrade/OCB/Renovate runbook live in
   (`metadata.yaml`, `.graphql`, `genqlient.yaml`) and regenerate with `make gen` / `make generate`.
 - **Regenerate and re-tidy after touching inputs.** After editing any `metadata.yaml`, `.graphql`,
   genqlient config, or dependencies, run `make generate` and `make tidy-all` (and `make crosslink`
-  if `replace`/module wiring changed) and commit the results. CI fails on any diff.
+  if `replace`/module wiring changed) and include the regenerated files in the change. CI fails on
+  any diff.
 - **Adding or removing a component means editing `config/manifest.yaml`** and running `make crosslink`
   — there is no other registry.
 - **Do not bump the semconv package as a side effect.** It is a deliberate manual migration; follow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,203 @@
+# liatrio-otel-collector
+
+Guidance for AI agents (and humans) working in this repository. This is the source of truth;
+`CLAUDE.md` is a symlink to it.
+
+`liatrio-otel-collector` is a custom OpenTelemetry Collector distribution. It bundles upstream
+collector/contrib components with a small set of Liatrio-authored components, most of which scrape
+software-delivery metrics from VCS platforms (GitHub, GitLab, Azure DevOps). The custom components
+are intended for eventual upstream contribution to opentelemetry-collector-contrib, so they follow
+upstream conventions closely.
+
+## Domain Glossary
+
+- **Distribution** — a collector binary built from a chosen set of components. This repo is one such
+  distribution; its binary is `otelcol-custom`.
+- **Component** — a receiver, processor, exporter, connector, or extension. The custom components
+  here are four receivers, one processor, and one extension.
+- **OCB** (OpenTelemetry Collector Builder) — `go.opentelemetry.io/collector/cmd/builder`; assembles
+  the distribution binary from `config/manifest.yaml`. Invoked by `make build`.
+- **`config/manifest.yaml`** — the OCB build manifest and the **only** place components are wired
+  into the build (`gomod:` lines plus a local `replaces:` block). There is no hand-written registry.
+- **Factory pattern** — the upstream OTel registration idiom; each component exposes `NewFactory()`.
+- **Scraper** — a pull-based metrics source inside a receiver. Three receivers use a pluggable
+  **multi-scraper** design (see [Receiver scraper pattern](#receiver-scraper-pattern)).
+- **`metadata.yaml`** — the declarative source describing a component (type, status, attributes,
+  metrics). Input to mdatagen.
+- **mdatagen** — code generator that turns a component's `metadata.yaml` into its
+  `internal/metadata/` package and `documentation.md`.
+- **genqlient** — GraphQL client generator (Khan/genqlient) that turns `schema.graphql` +
+  `genqlient.graphql` into generated Go for GraphQL-based scrapers.
+- **semconv** — OpenTelemetry Semantic Conventions. The **spec** and the Go **package** version
+  separately; see [`docs/semantic-conventions.md`](docs/semantic-conventions.md).
+- **multimod** — OTel build tool that manages module-set versions from `versions.yaml` at release.
+- **crosslink** — OTel build tool that syncs/prunes `replace` directives across module `go.mod`s.
+- **otel-compgen** — in-repo CLI (`cmd/otel-compgen`) that scaffolds new components.
+
+## Repository layout
+
+A **Go multi-module monorepo**: each custom component is its own Go module with its own
+`go.mod`/`go.sum`/`Makefile`. The root module (`github.com/liatrio/liatrio-otel-collector`) is mostly
+build/config glue.
+
+- `receiver/githubreceiver`, `receiver/gitlabreceiver`, `receiver/githubactionsreceiver`,
+  `receiver/azuredevopsreceiver` — custom receivers
+- `processor/gitlabprocessor` — custom processor
+- `extension/githubappauthextension` — GitHub App auth extension
+- `cmd/otel-compgen` — component scaffolding CLI (separate module `github.com/liatrio/otel-compgen`)
+- `config/manifest.yaml` — OCB build manifest (the component wiring)
+- `config/config.yaml` — runtime collector config used by `make run`
+- `internal/tools` — pinned build-tool dependencies (`tools.go`); binaries build into `.tools/`
+- `versions.yaml` — module-set versions managed by multimod for releases
+- `docs/` — cross-cutting policy/reference docs (e.g. `semantic-conventions.md`)
+- `build/` — OCB output (generated `main.go` + compiled `otelcol-custom`); do not hand-edit
+
+## Common commands
+
+All commands are Make targets. `install-tools` builds pinned tool binaries from `internal/tools`
+into `.tools/`; most targets depend on it. Multi-module targets (`*-all`) fan out over every
+directory containing a `go.mod` (excluding `build/` and `tmp/`) via the `for-all` helper.
+
+```bash
+make build          # build the otelcol-custom binary via OCB into ./build
+make run            # build then run with config/config.yaml
+make build-debug    # build with delve debug symbols (for the VS Code debug flow)
+make dockerbuild    # cross-build linux/amd64 and produce a local Docker image
+
+make checks         # full local CI gate: generate, fmt-all, tidy-all, lint-all, test-all, scan-all, multimod-verify, crosslink
+make lint-all       # golangci-lint across all modules
+make test-all       # go test across all modules (with coverage)
+make generate       # run `go generate` (mdatagen + genqlient) across all modules
+make tidy-all       # go mod tidy across all modules
+make crosslink      # sync/prune replace directives across module go.mod files
+```
+
+Per-module targets (run from inside a component directory, defined in `Makefile.Common`):
+
+```bash
+make test           # go test -v ./... with coverage for this module
+make lint           # golangci-lint run
+make gen            # go generate ./... then fmt (regenerate this component's code)
+make fmt            # goimports + go fmt + go mod tidy
+```
+
+### Running a single test
+
+`cd` into the component's module first (tests only see their own module), then use plain `go test`:
+
+```bash
+cd receiver/githubreceiver
+go test ./internal/scraper/githubscraper/ -run TestScrape -v
+```
+
+## Code generation (critical)
+
+Two independent codegen pipelines run from `//go:generate` directives (usually in each component's
+`doc.go`). Generated files are **never hand-edited** — they are marked `DO NOT EDIT` and flagged
+`linguist-generated` in `.gitattributes`.
+
+1. **mdatagen** — `.tools/mdatagen metadata.yaml`. Consumes a component's `metadata.yaml` and
+   produces the entire `internal/metadata/` package (`generated_config.go`, `generated_metrics.go`,
+   `generated_resource.go`, `generated_status.go`), the root `generated_*_test.go` files, and
+   `documentation.md`. Hand-written factories consume the output (`metadata.Type`,
+   `metadata.MetricsStability`, `metadata.NewDefaultMetricsBuilderConfig()`, etc.). To add or change
+   a metric/attribute, edit `metadata.yaml` and run `make gen`.
+
+2. **genqlient** — `.tools/genqlient`. GraphQL-based scrapers keep three hand-written inputs —
+   `schema.graphql` (upstream API schema), `genqlient.graphql` (queries), `genqlient.yaml` (config +
+   scalar bindings) — and generate `generated_graphql.go` / `generated.go`.
+
+CI fails if regenerating produces a diff, so **run `make generate` and commit the result** after
+touching any `metadata.yaml`, `.graphql`, or genqlient config. Editing templates in `cmd/otel-compgen`
+requires rebuilding that binary — templates are compiled in via `//go:embed`.
+
+## Component architecture
+
+Custom components use the standard upstream OTel factory pattern. Each exposes `NewFactory()` built
+from `metadata.Type`, a `createDefaultConfig`, and signal-specific create funcs gated by generated
+stability constants (e.g. `receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability)`).
+Config types embed upstream config structs with `mapstructure:",squash"`, assert interface
+conformance with blank-var checks (`_ component.Config = (*Config)(nil)`), and implement `Validate()`.
+
+### Receiver scraper pattern
+
+Three receivers (`githubreceiver`, `gitlabreceiver`, `azuredevopsreceiver`) use a pluggable
+multi-scraper design:
+
+- `receiver/<name>/internal/scraper.go` defines a `ScraperFactory` interface
+  (`CreateDefaultConfig`, `CreateMetricsScraper`).
+- Concrete scrapers live under `receiver/<name>/internal/scraper/<xscraper>/`, each with its own
+  `factory.go` (a `TypeStr` const + `Factory` struct implementing `ScraperFactory`), `config.go`,
+  scrape logic, and — for GraphQL scrapers — their own genqlient files.
+- The receiver's root `factory.go` registers scrapers in a `scraperFactories map[string]ScraperFactory`
+  keyed by `TypeStr`, and builds the receiver via `scraperhelper.NewMetricsController`.
+- Config binds scrapers dynamically: `Config.Scrapers map[string]internal.Config` plus a custom
+  `Unmarshal` that resolves each key to its factory's default config. `Validate()` requires at least
+  one scraper.
+
+`githubreceiver` is the richest: it supports both metrics (scrapers) and traces (a webhook), so its
+factory registers `WithMetrics` and `WithTraces`. `githubactionsreceiver` is the exception — it has
+**no scrapers**; it is a webhook/push traces-only receiver.
+
+### Creating a new component
+
+Use otel-compgen (see `cmd/otel-compgen/README.md`). It scaffolds a minimal, compiling skeleton
+(factory, config, doc, metadata.yaml, Makefile importing `Makefile.Common`, etc.) from a full module
+path, e.g. `otel-compgen receiver github.com/liatrio/liatrio-otel-collector/receiver/myreceiver ./receiver/myreceiver`.
+Only the receiver (pull/scraper metrics) path is implemented. After scaffolding: run `make gen`,
+implement the component logic, and add the module to `config/manifest.yaml`.
+
+## Semantic conventions
+
+**Rule of thumb: when in doubt, default to the semconv spec** — but to the spec version our packages
+declare, not whatever is newest upstream. The **spec** (human-readable conventions, latest 1.43) and
+the **package** (`otel/semconv/vX` Go constants, latest 1.41) are separate version axes; the package
+lags the spec and is the hard ceiling (mdatagen can't stamp an import that doesn't exist). **Renovate
+does not bump the semconv package** — that is a manual step. Where the spec has no convention, we
+define local "extension" attributes; when the spec defines one, the spec name replaces the extension.
+The repo is **not** on a single version (declared `sem_conv_version` ranges 1.27.0–1.37.0 and differs
+within components), so verify before relying on it. Full policy, the version matrix, the extensions
+register, and the package-upgrade/OCB/Renovate runbook live in
+[`docs/semantic-conventions.md`](docs/semantic-conventions.md).
+
+## Conventions & CI
+
+- Commits must be **Conventional Commits** (enforced by a `commit-msg` pre-commit hook and a PR check).
+- `pre-commit install` is expected; hooks run `make check-generate`, yamlfmt, json formatting, and markdownlint.
+- Lint config is `.golangci.yaml` (Go 1.24, line length 185). Formatting is `goimports` + `gofmt`.
+- CI (`.github/workflows/build.yml`) only runs real jobs on PRs targeting `main`. It re-runs
+  `make generate`, `make tidy-all`, and `make crosslink` and fails on any resulting diff — so keep
+  generated code, module tidiness, and replace directives committed.
+- Releases are automated on `main` via multimod + semantic versioning driven by `versions.yaml`
+  (the `liatrio-otel` module set).
+
+## Guardrails
+
+- **Never hand-edit generated files** — `internal/metadata/generated_*.go`, `generated_graphql.go` /
+  `generated.go`, `documentation.md`, and `internal/metadata/testdata/config.yaml`. Change the source
+  (`metadata.yaml`, `.graphql`, `genqlient.yaml`) and regenerate with `make gen` / `make generate`.
+- **Regenerate and re-tidy after touching inputs.** After editing any `metadata.yaml`, `.graphql`,
+  genqlient config, or dependencies, run `make generate` and `make tidy-all` (and `make crosslink`
+  if `replace`/module wiring changed) and commit the results. CI fails on any diff.
+- **Adding or removing a component means editing `config/manifest.yaml`** and running `make crosslink`
+  — there is no other registry.
+- **Do not bump the semconv package as a side effect.** It is a deliberate manual migration; follow
+  the runbook in [`docs/semantic-conventions.md`](docs/semantic-conventions.md).
+- **Never commit unless explicitly asked**, and never `git commit --no-verify` — it bypasses the
+  conventional-commit and generate checks.
+- **No destructive git operations without confirmation**: `push --force`, `reset --hard`,
+  `branch -D`, or history rewrites on `main`. Branch off `main`; do not work on `main` directly.
+- **Verify before claiming done.** For the changed module, run `make build` (or `make lint` +
+  `make test`), plus `make generate` if you touched generated inputs. Do not claim a change works
+  without building it.
+
+## Keeping docs current
+
+When you add or rename a component, change a build/test command, alter the codegen or scraper
+architecture, or change the semconv posture, update docs **as part of the change, not a follow-up**:
+
+- **`AGENTS.md`** (this file; `CLAUDE.md` is a symlink to it) — if it changes how an agent navigates,
+  builds, or reasons about the repo.
+- **`docs/semantic-conventions.md`** — if the semconv version matrix, extensions register, or upgrade
+  process changes.
+- **The component's own `README.md` and `metadata.yaml`** — regenerate `documentation.md` afterward.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,98 @@
+# Release Process
+
+Releases are **fully automated** off `main` — no manual version bumps or tagging. This document
+describes the pipeline, the role of [multimod](#multimod), and how to verify a release locally.
+
+## multimod
+
+[multimod][multimod] (`go.opentelemetry.io/build-tools/multimod`, pinned in `internal/tools`) adds
+versioning to a repo containing multiple Go modules. It versions a **module set** — a named group of
+modules released together — driven by `versions.yaml`. It is the standard release mechanism across
+the upstream OpenTelemetry collector repos.
+
+`versions.yaml` defines the set:
+
+```yaml
+module-sets:
+  liatrio-otel:
+    version: v0.102.1        # the set's current version
+    modules: [ ... ]         # modules versioned + tagged together
+excluded-modules: [ ... ]    # modules deliberately NOT versioned
+```
+
+Subcommands used here:
+
+| Subcommand | Where | What it does |
+|---|---|---|
+| `verify` | `make multimod-verify` (in `make checks`) | Validates `versions.yaml`: every module in exactly one set, semver sanity |
+| `prerelease` | `make multimod-prerelease` + CI | Rewrites the `go.mod` versions across the set and creates the `Prepare liatrio-otel for version vX` commit |
+| `tag` | CI (`create-release.yml`) | Creates a git tag per module in the set at the merged commit |
+
+`make multimod-prerelease` runs `multimod prerelease -b=false -v ./versions.yaml -m liatrio-otel`
+(`-b=false` = operate on the current branch instead of creating a new one).
+
+## The pipeline
+
+Three workflows chain together, gated by the commit author (`octo-sts[bot]`) and message. A single
+merge to `main` walks all the way to published artifacts with no human action after the merge.
+
+```
+merge PR to main
+      │
+      ▼
+build.yml : multimod-prepare-release   (actor ≠ octo-sts[bot])
+  • compute next version from Conventional Commits
+  • yq-write it into versions.yaml
+  • commit "chore: run multimod to update versions ahead of release(version vX)"
+  • make multimod-prerelease  →  commit "Prepare liatrio-otel for version vX"
+  • push to main (as octo-sts[bot])
+      │
+      ▼
+create-release.yml : create-release    (actor = octo-sts[bot], message starts "Prepare liatrio-otel for version")
+  • build changelog from Conventional Commits
+  • GPG-sign, multimod tag --module-set-name liatrio-otel --commit-hash <sha>
+  • git push --tags
+  • gh release create <tag> --notes <changelog>
+      │
+      ▼
+release.yml : release                  (trigger: GitHub Release "created")
+  • GoReleaser Pro (.goreleaser.yaml): cross-platform binaries + archives,
+    multi-arch Docker images (linux 386/amd64/arm64) pushed to ghcr.io
+```
+
+The `octo-sts[bot]` author gate is what prevents infinite loops: `build.yml` jobs skip when the
+actor **is** the bot, and `create-release.yml` only runs when it **is** the bot with a
+`Prepare liatrio-otel for version` commit.
+
+### Version bumping
+
+The next version is derived from Conventional Commit types since the last release (via
+`thenativeweb/get-next-version` in `build.yml`, and `mathieudutour/github-tag-action` for the
+changelog in `create-release.yml`): `feat:` → minor, `fix:` / `chore:` → patch. This is why commit
+message discipline matters — commits drive the version.
+
+## Verifying locally
+
+You cannot cut a release locally (it requires the bot identity and signing keys), but you can
+validate the versioning config and dry-run the artifact build:
+
+```bash
+make multimod-verify   # validate versions.yaml (also runs as part of `make checks`)
+make release           # local goreleaser snapshot (no publish) — see the Makefile note on OSS vs Pro
+```
+
+Note: `make release` uses the OSS GoReleaser installed via `internal/tools`, which does not support
+the `partial:` option used in CI (`goreleaser-pro`); it is a smoke test, not a faithful CI build.
+
+## Module-set membership caveat
+
+`versions.yaml` versions and tags **five** modules: the root module, `githubreceiver`,
+`gitlabreceiver`, `githubactionsreceiver`, and `githubappauthextension`. `internal/tools` and
+`otel-compgen` are explicitly excluded.
+
+`receiver/azuredevopsreceiver` and `processor/gitlabprocessor` are their own Go modules and ship in
+the build (`config/manifest.yaml`), but are **neither in the module set nor in `excluded-modules`**,
+so multimod does not version or tag them with the rest of the release. Confirm this is intentional
+before relying on their tags; if it is not, add them to the `liatrio-otel` module set.
+
+[multimod]: https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/multimod

--- a/docs/semantic-conventions.md
+++ b/docs/semantic-conventions.md
@@ -7,8 +7,8 @@ keeping that current.
 ## Rule of thumb: when in doubt, default to the spec
 
 Every attribute, metric, resource, and namespace we emit should follow the upstream semconv
-**spec** unless there is no convention for it yet. Do not invent local names for things the spec
-already defines, and do not diverge from spec naming for convenience.
+**spec** unless there is no convention for it yet. Reuse the spec's existing names for anything it
+already defines, and match its naming exactly rather than adapting it for convenience.
 
 **Follow the version of the spec that our packages declare, not whatever is newest upstream.** See
 [Spec vs. package](#spec-vs-package): the spec moves faster than the Go package, and we can only

--- a/docs/semantic-conventions.md
+++ b/docs/semantic-conventions.md
@@ -1,0 +1,129 @@
+# Semantic Conventions Policy
+
+This document is the single source of truth for how this distribution relates to OpenTelemetry
+[Semantic Conventions][semconv] (semconv), which version(s) we currently target, and the process for
+keeping that current.
+
+## Rule of thumb: when in doubt, default to the spec
+
+Every attribute, metric, resource, and namespace we emit should follow the upstream semconv
+**spec** unless there is no convention for it yet. Do not invent local names for things the spec
+already defines, and do not diverge from spec naming for convenience.
+
+**Follow the version of the spec that our packages declare, not whatever is newest upstream.** See
+[Spec vs. package](#spec-vs-package): the spec moves faster than the Go package, and we can only
+emit what the pinned package provides constants for. When referencing the spec while writing a
+component, use the spec revision matching that component's declared `sem_conv_version`.
+
+Where the spec has no convention for something, we define a **local extension**, following the
+shape and namespace of the closest existing spec area (e.g. new VCS attributes live under `vcs.*`,
+following the patterns of the existing `vcs.*` / `deploy.*` conventions). Local extensions are
+recorded in the [Extensions register](#extensions-register). When the spec defines a convention that
+an extension covers, the spec name replaces the extension.
+
+## Spec vs. package
+
+Two different things carry a semconv version number, and they do not move together:
+
+| | What it is | Latest | Bumped by |
+|---|---|---|---|
+| **The spec** | Human-readable conventions ([opentelemetry.io][semconv] / the [semantic-conventions repo][sc-repo]) | **1.43** | N/A — published upstream |
+| **The package** | `go.opentelemetry.io/otel/semconv/vX` Go constants we import | **1.41** (two versions behind the spec) | **Manually** — Renovate does **not** bump the version selection (see [runbook](#package-upgrade--ocb--renovate-runbook)) |
+
+Consequences of the gap:
+
+- The package is the **hard ceiling**. mdatagen stamps an `otel/semconv/vX` import derived from a
+  component's `sem_conv_version`, so a component cannot declare a spec version with no corresponding
+  package — there is no `otel/semconv/v1.43.0` to import.
+- The newest package (1.41) is two versions behind the spec (1.43). Spec conventions introduced
+  after 1.41 have no Go constants in this distribution.
+
+## Current state (verify before trusting — see [How to verify](#how-to-verify))
+
+> **We are not on a single version.** Declared `sem_conv_version` ranges from **1.27.0 to 1.37.0**
+> across components; the newest package available upstream is **1.41**; the newest spec is **1.43**.
+> Within a component, generated and hand-written code can target different package versions. The
+> table is what is actually in the tree.
+
+| Component | `sem_conv_version` (declared spec) | Generated code import (package) | Hand-written code import (package) | Notes |
+|---|---|---|---|---|
+| `receiver/githubreceiver` | 1.27.0 | `otel/semconv/v1.27.0` | `otel/semconv/v1.34.0` | Intra-component split: metrics gen on 1.27.0, trace code (`model.go`, `trace_event_handling.go`) on 1.34.0 |
+| `receiver/gitlabreceiver` | 1.27.0 | `otel/semconv/v1.27.0` | — | |
+| `processor/gitlabprocessor` | 1.27.0 | — | — | |
+| `receiver/azuredevopsreceiver` | 1.37.0 | `otel/semconv/v1.37.0` | — | Uses `vcs.provider.name` |
+
+The two version signals per component and how they relate:
+
+1. **`sem_conv_version:` in `metadata.yaml`** — declares the **spec** revision the component follows.
+   mdatagen stamps a matching `otel/semconv/vX` **package** import into
+   `internal/metadata/generated_metrics.go`, which is why this value cannot exceed an available
+   package version.
+2. **`otel/semconv/vX` imports in hand-written Go** — the **package** constants the runtime code
+   uses. Chosen by hand; can differ from the declared `sem_conv_version`.
+
+## How to verify
+
+Re-derive the table above at any time — do not trust a hardcoded number:
+
+```bash
+# Declared spec version per component
+grep -rn 'sem_conv_version' --include='metadata.yaml' .
+
+# Actual package imports in Go (generated + hand-written), grouped
+grep -rn 'go.opentelemetry.io/\(collector\|otel\)/semconv/v' --include='*.go' . | sort -u
+```
+
+- **Latest spec:** the [semantic-conventions releases][sc-releases] / [changelog][sc-changelog].
+- **Latest package:** the newest published `go.opentelemetry.io/otel/semconv/vX.Y.Z` (the Go module
+  proxy / [pkg.go.dev][pkg]). This is the ceiling for `sem_conv_version`.
+
+Record what you find rather than relying on memory — both move, and the package trails the spec.
+
+## Extensions register
+
+Attributes/metrics we emit that are not in the spec, or where we diverge from it.
+
+| Extension | Where | Spec status |
+|---|---|---|
+| `vcs.vendor.name` | `receiver/githubreceiver` | Superseded — the spec renamed this to `vcs.provider.name`, which `azuredevopsreceiver` uses |
+| `work_item.*` | `receiver/azuredevopsreceiver` | No spec convention for work items |
+| `cve.severity` | `receiver/githubreceiver` | No verified spec equivalent under `cve.*` / vulnerability conventions |
+
+## Package upgrade & OCB / Renovate runbook
+
+**Renovate bumps OCB and the `go.opentelemetry.io/collector` / contrib modules in one large PR, but
+it does *not* bump the semconv package selection.** The `otel/semconv/vX` version — both the
+`sem_conv_version` in each `metadata.yaml` and the hand-written imports — is chosen by us and is
+updated manually as part of a deliberate migration. An OCB bump does not move semconv.
+
+To move a component to a newer semconv **package**:
+
+1. **Pick the target package version** — no higher than the newest published `otel/semconv/vX`
+   (currently 1.41).
+2. **Diff the spec across the jump** — read the [changelog][sc-changelog] between the component's
+   current `sem_conv_version` and the target, focusing on `vcs.*`, `cicd.*`, and `deploy.*`. Note
+   renames, additions, removals, and stability changes.
+3. **Reconcile differences** — update attribute/metric names in `metadata.yaml`, adjust scraper
+   logic, and check the [Extensions register](#extensions-register) for extensions the spec now
+   covers.
+4. **Update both version signals together** — set the new `sem_conv_version` *and* bump the
+   hand-written `otel/semconv/vX` imports so they agree.
+5. **Regenerate and commit** — `make gen`, then commit the regenerated `internal/metadata/` and
+   `documentation.md`.
+6. **Note the package version** each component targets after the change in the PR description.
+
+When reviewing an OCB / collector-core Renovate PR, confirm it did not change any semconv import —
+re-derive the [version table](#how-to-verify) before and after and diff it.
+
+## References
+
+- OpenTelemetry Semantic Conventions (spec): <https://opentelemetry.io/docs/specs/semconv/>
+- VCS metrics: <https://opentelemetry.io/docs/specs/semconv/cicd/cicd-metrics/#vcs-metrics>
+- semconv repo / changelog: <https://github.com/open-telemetry/semantic-conventions>
+- Go packages: <https://pkg.go.dev/go.opentelemetry.io/otel/semconv>
+
+[semconv]: https://opentelemetry.io/docs/specs/semconv/
+[sc-repo]: https://github.com/open-telemetry/semantic-conventions
+[sc-releases]: https://github.com/open-telemetry/semantic-conventions/releases
+[sc-changelog]: https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md
+[pkg]: https://pkg.go.dev/go.opentelemetry.io/otel/semconv


### PR DESCRIPTION
## Summary

Adds AI-agent / contributor guidance to the repo, split into a tool-neutral entry file and a cross-cutting policy doc.

- **`AGENTS.md`** — source of truth for agent guidance; **`CLAUDE.md` is now a symlink to it** (tool-neutral, works for any agentic tool). Covers repo layout, build commands, the mdatagen/genqlient codegen pipelines, the component factory + multi-scraper architecture, a **domain glossary**, a **guardrails** section, and a **keeping-docs-current** directive.
- **`docs/semantic-conventions.md`** — policy for how this distribution tracks OpenTelemetry Semantic Conventions:
  - the **spec vs. package** version split (spec latest 1.43, Go package latest 1.41 — the hard ceiling)
  - the current **per-component version matrix** (declared `sem_conv_version` ranges 1.27.0–1.37.0, with intra-component drift documented as-is)
  - an **extensions register** of attributes not yet in the spec (e.g. `vcs.vendor.name`, `work_item.*`, `cve.severity`)
  - a manual **package-upgrade / OCB / Renovate runbook** (Renovate does *not* bump the semconv package — that's a deliberate manual step)

Docs only — no code or build changes.

## Notes

- Version numbers in the semconv doc (spec 1.43 / package 1.41) reflect current knowledge; the doc includes the grep commands and upstream links to re-verify them rather than trusting the hardcoded values.
- The `vcs.vendor.name` → `vcs.provider.name` divergence is documented in the extensions register but intentionally not yet migrated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance covering the project structure, common development workflows, testing, code generation, architecture, CI, and release practices.
  * Added semantic conventions documentation, including versioning policies, verification steps, local extensions, and upgrade guidance.
  * Consolidated development guidance so related documentation stays synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->