### PR TITLE
feat: add Tier-1 automatic regen CI job for Renovate PRs

### DIFF
--- a/.github/chainguard/regen.sts.yaml
+++ b/.github/chainguard/regen.sts.yaml
@@ -1,0 +1,9 @@
+---
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:liatrio/liatrio-otel-collector:pull_request
+
+claim_pattern:
+  head_ref: ^renovate/.*
+
+permissions:
+  contents: write

--- a/.github/chainguard/regen.sts.yaml
+++ b/.github/chainguard/regen.sts.yaml
@@ -1,9 +1,19 @@
 ---
+# Trust policy for the `regen` octo-sts identity (see the `regen` job in
+# .github/workflows/build.yml). octo-sts reads this from the DEFAULT BRANCH, not the PR head,
+# so a PR can't widen it — this file, not the tamperable `if:` guard in build.yml, is the
+# real gate on who can mint the token.
 issuer: https://token.actions.githubusercontent.com
+
+# PR-triggered runs of this repo only (auto-anchored ^...$, so never push/main or pull_request_target).
 subject_pattern: repo:liatrio/liatrio-otel-collector:pull_request
 
 claim_pattern:
   head_ref: ^renovate/.*
+  # Run must be initiated by renovate[bot] (id 29139614). actor_id is GitHub-signed and
+  # unspoofable; head_ref alone isn't enough (anyone can name a branch renovate/*). This
+  # rejects a human's commit pushed to a Renovate PR and fork PRs. Numeric id is rename-stable.
+  actor_id: "29139614"
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,10 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          # Do not leave the write-capable octo-sts token in the git credential store for the
+          # duration of the job — the regen steps below run PR-provided (Renovate-bumped) code, so
+          # the push step authenticates explicitly instead of relying on a persisted credential.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -177,6 +181,13 @@ jobs:
       # Renovate treats a foreign commit as a signal to stop auto-rebasing that branch, which is the
       # outcome we want: our fix sticks, and the PR is left for CI to go green and get merged.
       - name: Commit and push fixes
+        env:
+          # Pass the untrusted, user-controllable branch name and the octo-sts token through the
+          # environment rather than interpolating them into the shell — `${{ … }}` expansion happens
+          # before the script runs, so a crafted head ref could otherwise inject shell commands.
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
         run: |
           if git diff --quiet; then
             echo "No mechanical fixes needed; nothing to commit."
@@ -184,7 +195,7 @@ jobs:
           fi
           git add .
           git commit -m "chore: run make generate"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${HEAD_REF}"
 
   build:
     name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,83 @@ jobs:
             exit 1
           fi
 
+  regen:
+    name: regen
+    needs: [generate, lint]
+    # Only runs when Tier 1 (generate/lint) failed on a renovate[bot] PR, and never on a push made
+    # by the octo-sts bot itself (this job's own commit re-triggers `synchronize`, which would
+    # otherwise recurse). This is a plain AND, not the repo's default OR'd/ref-negated guard, because
+    # this job must never run on `main` or on non-Renovate PRs regardless of failure() state.
+    if: failure() && github.event.pull_request.user.login == 'renovate[bot]' && github.actor != 'octo-sts[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Get Octo STS Token
+        uses: octo-sts/action@210248e8ae1ae1550aa6e232c6f192b3ccbf7335
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: regen
+
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/octo-sts[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+
+      - name: Configure git committer
+        run: |
+          git config user.name 'octo-sts[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+octo-sts[bot]@users.noreply.github.com'
+
+      - name: Make install-tools
+        run: make install-tools
+
+      - name: Run mechanical regeneration
+        run: |
+          make generate
+          make tidy-all
+          make crosslink
+          make fmt-all
+
+      - name: Refuse to push workflow changes
+        run: |
+          if ! git diff --quiet --name-only -- .github/; then
+            echo "Regeneration touched .github/** — refusing to commit/push a workflow-poisoning diff."
+            git diff --name-only -- .github/
+            exit 1
+          fi
+
+      # Deliberately does NOT re-apply Renovate's `rebase` label after pushing. Re-adding it would
+      # tell Renovate to force-rebase the branch from the dependency update on its next run, which
+      # recreates the branch and discards this foreign commit — undoing the fix and looping forever.
+      # Renovate treats a foreign commit as a signal to stop auto-rebasing that branch, which is the
+      # outcome we want: our fix sticks, and the PR is left for CI to go green and get merged.
+      - name: Commit and push fixes
+        run: |
+          if git diff --quiet; then
+            echo "No mechanical fixes needed; nothing to commit."
+            exit 0
+          fi
+          git add .
+          git commit -m "chore: run make generate"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
   build:
     name: build
     if: github.ref != 'refs/heads/main' || ( github.ref == 'refs/heads/main' && github.actor != 'octo-sts[bot]')


### PR DESCRIPTION
## Summary
- Adds a `regen` job to `.github/workflows/build.yml` that runs when Tier 1 (`generate`/`lint`) fails on a `renovate[bot]` PR: it re-runs `make generate`/`tidy-all`/`crosslink`/`fmt-all` and pushes the mechanical fixes back to the PR branch, so routine Renovate-driven regen diffs don't require a human to intervene.
- Adds `.github/chainguard/regen.sts.yaml`, the octo-sts trust policy scoping the `regen` identity's token to PR-triggered runs on `renovate/*` branches only.
- The job refuses to push if regeneration touches `.github/**`, and deliberately does not re-apply Renovate's `rebase` label (which would otherwise cause Renovate to force-rebase the branch and discard the fix in a loop).

## Test plan
- [ ] Confirm `build.yml` parses and the new `regen` job is visible in the Actions UI for this PR
- [ ] Open a test Renovate PR (or simulate `pull_request` context) that fails Tier 1, and confirm `regen` runs, pushes a fix commit, and does not recurse
- [ ] Confirm the job never fires on non-Renovate PRs or on `push` to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated regeneration CI job for eligible Renovate pull requests when primary checks fail.
  * Automatically commits and pushes regeneration output back to the pull request branch.
  * Includes safeguards to avoid running on the main branch, prevent workflow-file changes from being re-pushed, and reduce the risk of regeneration loops.
* **Security**
  * Tightened the CI’s STS trust and token permissions required for the regeneration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->