### PR TITLE
fix(ci): guard regen job against silently reverting dependency bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,12 +160,42 @@ jobs:
       - name: Make install-tools
         run: make install-tools
 
+      # A Go major-version dependency bump (e.g. backoff/v5 -> backoff/v7) adds a new require line
+      # that nothing imports yet — the source-level import-path migration is a judgment-tier change
+      # Tier 1 doesn't attempt. `go mod tidy` then "correctly" drops that unused, newly-added line,
+      # which silently undoes the bump instead of fixing codegen drift. This snapshot, compared
+      # after the mechanical fixes below, is what lets the next step catch that and refuse to push.
+      - name: Snapshot module requirements (pre-fix)
+        run: |
+          find . -not -path './build/*' -not -path './tmp/*' -name go.mod | sort | while read -r mod; do
+            dir=$(dirname "$mod")
+            go -C "$dir" mod edit -json | jq -r --arg dir "$dir" '(.Require // [])[] | "\($dir)\t\(.Path)@\(.Version)"'
+          done > /tmp/regen-reqs-before.txt
+
       - name: Run mechanical regeneration
         run: |
           make generate
           make tidy-all
           make crosslink
           make fmt-all
+
+      - name: Refuse to silently drop dependency requirements
+        run: |
+          find . -not -path './build/*' -not -path './tmp/*' -name go.mod | sort | while read -r mod; do
+            dir=$(dirname "$mod")
+            go -C "$dir" mod edit -json | jq -r --arg dir "$dir" '(.Require // [])[] | "\($dir)\t\(.Path)@\(.Version)"'
+          done > /tmp/regen-reqs-after.txt
+          removed=$(comm -23 <(sort /tmp/regen-reqs-before.txt) <(sort /tmp/regen-reqs-after.txt))
+          if [ -n "$removed" ]; then
+            echo "Mechanical regeneration would remove module requirement(s) present before this job ran:"
+            echo "$removed"
+            echo
+            echo "This usually means the bump needs a source-level change (e.g. a Go major-version"
+            echo "import-path migration) that Tier 1 can't perform, and 'go mod tidy' is dropping the"
+            echo "newly-added, still-unused requirement instead of completing it. Refusing to"
+            echo "commit/push; leaving this PR failing for manual or /fix-skill follow-up."
+            exit 1
+          fi
 
       - name: Refuse to push workflow changes
         run: |


### PR DESCRIPTION
## Summary

Extracted from the larger `feat/renovate-maintenance-agent` work for separate review — this is the **`build.yml` change only**.

PR #822 (the live `backoff/v5`->`v7` case) showed the Tier-1 regen job running `make tidy-all` after a Go major-version bump, which dropped the newly-added (and still-unused) `v7` requirement — the only line Renovate had added. Net effect: the PR's diff against `main` went empty, `build-and-test` stopped triggering (path-filtered on an empty diff), and the PR showed as cleanly mergeable while being a silent no-op.

## Change

Add a pre/post snapshot of each `go.mod`'s requirements (via `go mod edit -json`) around the mechanical-fix steps in the regen job; refuse to commit/push if any requirement present *before* the fix is missing *after*. Verified locally against the actual PR-822 commits.

- **1 file changed, 30 insertions(+)** — `.github/workflows/build.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated regeneration checks to detect when required modules are unintentionally removed.
  * Regeneration now fails clearly instead of proceeding with incomplete dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->