### PR TITLE
fix(ci): stop failing-checks sidecar from emitting invalid JSON

### DIFF
--- a/.github/workflows/fix-agent.yml
+++ b/.github/workflows/fix-agent.yml
@@ -142,12 +142,13 @@ jobs:
             | grep -o '<!-- renovate-upgrades:.*-->' \
             | sed -e 's/^<!-- renovate-upgrades://' -e 's/-->$//' || true)"
           echo "$upgrades" | jq -e . >/dev/null 2>&1 || upgrades='[]'
-          # `gh pr checks` exits non-zero (8) whenever a check is failing — which is always true here,
-          # since /fix only runs on red PRs. Capture it separately so that expected exit code cannot
-          # poison the JSON-building pipeline under `set -o pipefail`, then validate + fall back to [].
-          checks="$(gh pr checks "$PR_NUMBER" -R "$REPO" 2>/dev/null || true)"
-          failing="$(printf '%s\n' "$checks" \
-            | awk -F '\t' 'tolower($2) ~ /fail/ {print $1}' | jq -R . | jq -s . 2>/dev/null)"
+          # `gh pr checks` exits non-zero whenever a check is failing (1) or pending (8) — which is
+          # always true here, since /fix only runs on red PRs. Capture it separately so that expected
+          # exit code cannot poison the pipeline under `set -o pipefail`, then validate + fall back to
+          # []. Parse the machine-readable `bucket` field (gh's own pass/fail/pending/... categorization)
+          # rather than scraping the human TSV table.
+          checks="$(gh pr checks "$PR_NUMBER" -R "$REPO" --json name,bucket 2>/dev/null || true)"
+          failing="$(printf '%s' "$checks" | jq -c '[.[] | select(.bucket == "fail") | .name]' 2>/dev/null)"
           echo "$failing" | jq -e . >/dev/null 2>&1 || failing='[]'
           # Make the base commit reachable in ./pr for the skill's CVE-delta gate, then record its SHA.
           git -C pr fetch --no-tags --depth=200 origin "$BASE_REF" 2>/dev/null || true

--- a/.github/workflows/fix-agent.yml
+++ b/.github/workflows/fix-agent.yml
@@ -142,8 +142,13 @@ jobs:
             | grep -o '<!-- renovate-upgrades:.*-->' \
             | sed -e 's/^<!-- renovate-upgrades://' -e 's/-->$//' || true)"
           echo "$upgrades" | jq -e . >/dev/null 2>&1 || upgrades='[]'
-          failing="$(gh pr checks "$PR_NUMBER" -R "$REPO" 2>/dev/null \
-            | awk -F '\t' 'tolower($2) ~ /fail/ {print $1}' | jq -R . | jq -s . || echo '[]')"
+          # `gh pr checks` exits non-zero (8) whenever a check is failing — which is always true here,
+          # since /fix only runs on red PRs. Capture it separately so that expected exit code cannot
+          # poison the JSON-building pipeline under `set -o pipefail`, then validate + fall back to [].
+          checks="$(gh pr checks "$PR_NUMBER" -R "$REPO" 2>/dev/null || true)"
+          failing="$(printf '%s\n' "$checks" \
+            | awk -F '\t' 'tolower($2) ~ /fail/ {print $1}' | jq -R . | jq -s . 2>/dev/null)"
+          echo "$failing" | jq -e . >/dev/null 2>&1 || failing='[]'
           # Make the base commit reachable in ./pr for the skill's CVE-delta gate, then record its SHA.
           git -C pr fetch --no-tags --depth=200 origin "$BASE_REF" 2>/dev/null || true
           base_sha="$(git -C pr merge-base FETCH_HEAD HEAD 2>/dev/null || echo '')"

--- a/.github/workflows/fix-agent.yml
+++ b/.github/workflows/fix-agent.yml
@@ -193,7 +193,9 @@ jobs:
           set -e
           echo "claude exit: $rc"
           # The skill's structured recap is the JSON "result" field; fall back to raw stdout/stderr.
-          jq -r '.result // .text // ""' out.json > recap.md 2>/dev/null || true
+          # select(length>0) so an empty-string result (not just a missing one) also falls through to
+          # stderr — `//` only substitutes on null, and jq would otherwise emit a blank recap.
+          jq -r '(.result // .text // "") | select(length>0)' out.json > recap.md 2>/dev/null || true
           [ -s recap.md ] || cp claude.stderr recap.md
           after="$(git -C pr rev-parse HEAD)"
           echo "post_sha=$after" >> "$GITHUB_OUTPUT"
@@ -239,7 +241,10 @@ jobs:
             fi
             echo
             if [ -f recap.md ]; then
-              # Fence the (untrusted-derived) recap so it can't be read as further instructions.
+              # Fold the (untrusted-derived) recap into a <details> block. This only collapses it
+              # visually — it does NOT neutralize markdown, mentions, or links, and a </details> in
+              # the recap escapes the fold. The recap is agent output over untrusted PR code, so a
+              # reader must treat its contents as untrusted, not as anything this workflow vouches for.
               echo '<details><summary>Structured recap</summary>'
               echo
               cat recap.md


### PR DESCRIPTION
## What

The `fix-agent` workflow's **Build failure-context sidecar** step fails with `jq: invalid JSON text passed to --argjson` (exit 2) on essentially every real `/fix` invocation. Observed in [run 29453440378](https://github.com/liatrio/liatrio-otel-collector/actions/runs/29453440378/job/87481137164) (PR #822).

## Root cause

```bash
failing="$(gh pr checks "$PR_NUMBER" -R "$REPO" 2>/dev/null \
  | awk ... | jq -R . | jq -s . || echo '[]')"
```

`gh pr checks` **exits non-zero (8) whenever a check is failing** — which is always the case for a `/fix` run, since `/fix` only targets red PRs. Under the step's `set -o pipefail`, that expected non-zero exit marks the whole pipeline as failed *even though `jq -s .` already printed a valid array to stdout*. The trailing `|| echo '[]'` then fires and appends a second `[]`, so the captured `failing` becomes two concatenated JSON documents:

```
[
  "some-failing-check"
]
[]
```

`jq --argjson` requires exactly one JSON value and rejects it → exit 2.

(The existing `jq -e .` validation used for `upgrades` would not have caught this: `jq -e` accepts a *stream* of values, but `--argjson` does not.)

## Fix

Capture `gh pr checks` separately so its expected exit code can't poison the JSON-building pipeline, then validate and fall back to `[]` — mirroring the pattern already used for `upgrades` just above.

Verified with a faithful `set -euo pipefail` reproduction that the old code reproduces the exact CI error and the new code yields valid single-document JSON. YAML re-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/fix` failure detection by using structured check results for more reliable reporting.
  * Prevented empty recap content from replacing available fallback error details.
  * Updated recap display behavior so Markdown content remains rendered correctly within expandable sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->