### PR TITLE
ci: pin GOTOOLCHAIN floor to avoid go1.25.0 linker bug

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -12,6 +12,10 @@ endif
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
+# Floor the Go toolchain so GOTOOLCHAIN=auto can't select the buggy go1.25.0
+# that OCB's build/go.mod pins as its floor. +auto still allows newer if required.
+export GOTOOLCHAIN ?= go1.26.5+auto
+
 # A lot of the following install tools commands were leveraged from the
 # Open Telemetry Contributor Makefile following the Go Paradigm for Third Party Tools
 # See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile.Common#L39-L74 for more details.


### PR DESCRIPTION
## What

Pins the Go toolchain floor once, in `Makefile.Common`, via:

```make
export GOTOOLCHAIN ?= go1.26.5+auto
```

`Makefile.Common` is included by the root `Makefile` **and** every component `Makefile`, so this covers every make-driven `go`/OCB invocation — `build`, `test`, `generate`, per-module targets — in CI **and** locally.

## Why

OCB (`builder v0.156.0`) stamps `go 1.25.0` into the generated `build/go.mod` with **no `toolchain` line**, because `config/manifest.yaml` has no `dist.go` knob. Under the default `GOTOOLCHAIN=auto`, an ambient Go *below* that floor makes `auto` fetch **exactly `go1.25.0`**, which carries a linker bug — the `pkg/ottl.WithConditionConverter` / `WithParserCollectionContext` generic instantiations (used by `filterprocessor`) are referenced only from `runtime.text` and fail to link:

```
Undefined symbols for architecture arm64:
  "_...pkg/ottl.WithConditionConverter[...ottlresource.TransformContext,go.shape...]"
  "_...pkg/ottl.WithParserCollectionContext[...]"
ld: symbol(s) not found
```

Reproduced by forcing `GOTOOLCHAIN=go1.25.0`; **1.26 links clean**. This is a host-toolchain bug, independent of any PR's changes. It first surfaced when the `/fix` agent on #822 reported `make build` failing.

## Why the Makefile floor instead of a per-workflow `setup-go` pin

The original version of this PR added a `setup-go '1.26'` step to `fix-agent.yml` only. That works solely because `1.26 > 1.25.0` flooring keeps `auto` on 1.26 — and it fixes just that one workflow. The same exposure exists anywhere without a Go pin above the floor:

- `fix-agent.yml` (no `setup-go`)
- `build.yml` → `multimod-prepare-release` job (no `setup-go`)
- `codeql.yml` (uses CodeQL's bundled Go SDK)
- **local `make build` / `make run` / pre-commit** for any contributor whose installed Go is below the floor

Setting `GOTOOLCHAIN` at the `Makefile.Common` level removes the buggy-version selection at its source and covers every path uniformly, instead of playing whack-a-mole per workflow.

`go1.26.5+auto` sets a known-good **minimum** (so `auto` can never land on `1.25.0`) while still allowing an upgrade if a module ever requires a newer toolchain. `?=` keeps it overridable from the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and development workflows to use Go 1.26.5 or later automatically.
  * Prevented affected workflows from selecting the known-incompatible Go 1.25.0 toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->